### PR TITLE
feat: add SNMPv3 HMAC-SHA-2 authentication (SHA-224/256/384/512)

### DIFF
--- a/ber.c
+++ b/ber.c
@@ -8,6 +8,8 @@
  */
 #include "sqe.h"
 
+#include <openssl/evp.h>
+
 #define SPACECHECK(bytes)                \
     if (e->len + (bytes) > e->max_len) { \
         errno = EMSGSIZE;                \
@@ -287,10 +289,16 @@ start_snmp_packet(struct packet_builder *pb, int version, unsigned request_id, c
         unsigned char *gdata, *sec_params_string, *sec_params_seq;
         unsigned char  msg_flags          = V3F_AUTHENTICATED | V3F_ENCRYPTED | V3F_REPORTABLE;
         unsigned int   msg_security_model = 3;    // HACK authFlag | privFlag
-        unsigned char  zeroes[32];
+        unsigned char  zeroes[EVP_MAX_MD_SIZE];
+        int            maclen             = v3_auth_maclen(v3->auth_proto);
+
+        if (maclen < 0) {
+            errno = EINVAL;
+            return -1;
+        }
 
         pb->pi.v3 = true;
-        memset(zeroes, 0, 32);
+        memset(zeroes, 0, sizeof(zeroes));
 
         SPACECHECK2;
         gdata    = e->b;
@@ -339,7 +347,7 @@ start_snmp_packet(struct packet_builder *pb, int version, unsigned request_id, c
         if (encode_string(v3->username, e) < 0)
             return -1;
         pb->pi.authp_offset = e->b - e->buf + 2;
-        if (encode_bytes(zeroes, 12, e) < 0)
+        if (encode_bytes(zeroes, maclen, e) < 0)
             return -1;
         pb->pi.privp_offset = e->b - e->buf + 2;
         if (encode_bytes(zeroes, 8, e) < 0)
@@ -452,7 +460,10 @@ finalize_snmp_packet(struct packet_builder *pb, struct ber *out_encoded_packet, 
 
     // authenticate
     if (pb->pi.v3 && v3) {
-        if (hmac_message(v3, e->buf + pb->pi.authp_offset, 12, e->buf, e->len, e->buf + pb->pi.authp_offset) < 0) {
+        int maclen = v3_auth_maclen(v3->auth_proto);
+        if (maclen < 0)
+            return -1;
+        if (hmac_message(v3, e->buf + pb->pi.authp_offset, maclen, e->buf, e->len, e->buf + pb->pi.authp_offset) < 0) {
             return -1;
         }
     }

--- a/request_common.c
+++ b/request_common.c
@@ -117,6 +117,18 @@ msgpack_pack_options(msgpack_packer *pk, struct client_requests_info *cri)
 		case V3O_AUTH_PROTO_SHA1:
 			s = "sha1";
 			break;
+		case V3O_AUTH_PROTO_SHA224:
+			s = "sha224";
+			break;
+		case V3O_AUTH_PROTO_SHA256:
+			s = "sha256";
+			break;
+		case V3O_AUTH_PROTO_SHA384:
+			s = "sha384";
+			break;
+		case V3O_AUTH_PROTO_SHA512:
+			s = "sha512";
+			break;
 		default:
 			s = "?";
 			break;

--- a/request_setopt.c
+++ b/request_setopt.c
@@ -222,6 +222,14 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 				v3.auth_proto = V3O_AUTH_PROTO_SHA1;
 			} else if (object_string_eq(v, "sha")) {
 				v3.auth_proto = V3O_AUTH_PROTO_SHA1;
+			} else if (object_string_eq(v, "sha224")) {
+				v3.auth_proto = V3O_AUTH_PROTO_SHA224;
+			} else if (object_string_eq(v, "sha256")) {
+				v3.auth_proto = V3O_AUTH_PROTO_SHA256;
+			} else if (object_string_eq(v, "sha384")) {
+				v3.auth_proto = V3O_AUTH_PROTO_SHA384;
+			} else if (object_string_eq(v, "sha512")) {
+				v3.auth_proto = V3O_AUTH_PROTO_SHA512;
 			} else {
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid auth protocol");
 			}

--- a/snmp.c
+++ b/snmp.c
@@ -8,6 +8,8 @@
  */
 #include "sqe.h"
 
+#include <openssl/evp.h>
+
 static struct socket_info *snmp = NULL;
 
 static void
@@ -75,7 +77,8 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 		unsigned msg_flags_len, username_len;
 		unsigned usm;
 		unsigned char *auth_param_ptr;
-		unsigned char auth_param[12];
+		unsigned auth_param_len = 0;
+		unsigned char auth_param[EVP_MAX_MD_SIZE];
 		unsigned char priv_param[8];
 		struct snmpv3info v3, *siv3;
 		unsigned char context_engine_id[V3O_ENGINE_ID_MAXLEN];
@@ -110,15 +113,8 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
         if (t != AT_STRING)
           goto bad_snmp_packet;
 		auth_param_ptr = e->b;
+		auth_param_len = l;  // validated below, once the configured protocol (siv3) is known
         e->b += l; e->len += l;
-		if ((v3.msg_flags & V3F_AUTHENTICATED)) {
-			if (l != 12) {
-				trace = "unexpected auth-param length for authenticated message";
-				goto bad_snmp_packet;
-			}
-			memcpy(auth_param, auth_param_ptr, 12);
-			memset(auth_param_ptr, 0, 12); // clear original HMAC location for auth calculations
-		}
 		CHECK("priv-param", decode_octets(e, priv_param, 8, &l));
 		if ((v3.msg_flags & V3F_ENCRYPTED) && l != 8) {
 			trace = "unexpected priv-param length for encrypted message";
@@ -170,18 +166,29 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
 		// - do auth check
 		if ((v3.msg_flags & V3F_AUTHENTICATED)) {
-    		if (hmac_message(siv3, auth_param_ptr, 12, e->buf, e->max_len, auth_param_ptr) < 0) {
-				memcpy(auth_param_ptr, auth_param, 12);
+			int maclen = v3_auth_maclen(siv3->auth_proto);
+			if (maclen < 0) {
+				trace = "unsupported auth protocol";
+				goto bad_snmp_packet;
+			}
+			if (auth_param_len != (unsigned)maclen) {
+				trace = "unexpected auth-param length for authenticated message";
+				goto bad_snmp_packet;
+			}
+			memcpy(auth_param, auth_param_ptr, maclen);
+			memset(auth_param_ptr, 0, maclen); // clear original HMAC location for auth calculations
+    		if (hmac_message(siv3, auth_param_ptr, maclen, e->buf, e->max_len, auth_param_ptr) < 0) {
+				memcpy(auth_param_ptr, auth_param, maclen);
 				fprintf(stderr, "%s: authentication failed: %s, prepare for packet dump:\n",
 						log, strerror(errno));
 				dump_buf(stderr, e->buf, e->max_len);
 				trace = NULL;
 				goto bad_snmp_packet;
 			}
-			if (memcmp(auth_param_ptr, auth_param, 12) != 0) {
+			if (memcmp(auth_param_ptr, auth_param, maclen) != 0) {
 				fprintf(stderr, "%s: authentication failed, calculated digest:\n", log);
-				dump_buf(stderr, auth_param_ptr, 12);
-				memcpy(auth_param_ptr, auth_param, 12);
+				dump_buf(stderr, auth_param_ptr, maclen);
+				memcpy(auth_param_ptr, auth_param, maclen);
 				fprintf(stderr, "prepare for packet dump:\n");
 				dump_buf(stderr, e->buf, e->max_len);
 				trace = NULL;

--- a/sqe.h
+++ b/sqe.h
@@ -200,7 +200,8 @@ struct packet_info
 	/// @brief offset in packet to 4 bytes of sid (request-id/message-id);
 	/// impl: v3: adjust for gdata and packet_sequence, v1/v2: adjust for pdu and packet_sequence
 	unsigned sid_offset;
-	/// @brief offset in packet to 12 bytes of msgAuthenticationParameters in SNMPv3 (HMAC-SHA-96);
+	/// @brief offset in packet to the msgAuthenticationParameters in SNMPv3;
+	/// the length is protocol-dependent (12/16/24/32/48 bytes, see v3_auth_maclen());
 	/// impl: adjust for sec_params_seq, sec_params_string, and packet_sequence
 	unsigned authp_offset;
 	/// @brief offset in packet to 8 bytes of msgPrivacyParameters in SNMPv3 (salt/iv);
@@ -300,11 +301,15 @@ struct destination
 #define V3O_USERNAME_MAXSIZE 64
 #define V3O_AUTHPASS_MAXSIZE 64
 #define V3O_PRIVPASS_MAXSIZE 64
-#define V3O_AUTHKUL_MAXSIZE  32
-#define V3O_PRIVKUL_MAXSIZE  32
+#define V3O_AUTHKUL_MAXSIZE  64  /* holds the largest localized key (SHA-512, 64 bytes) */
+#define V3O_PRIVKUL_MAXSIZE  64  /* localized privacy key is a full digest before AES truncation (SHA-512, 64 bytes) */
 
 #define V3O_AUTH_PROTO_MD5 1
 #define V3O_AUTH_PROTO_SHA1 2
+#define V3O_AUTH_PROTO_SHA224 3
+#define V3O_AUTH_PROTO_SHA256 4
+#define V3O_AUTH_PROTO_SHA384 5
+#define V3O_AUTH_PROTO_SHA512 6
 
 #define V3O_PRIV_PROTO_DES 1
 #define V3O_PRIV_PROTO_AES128 2
@@ -643,6 +648,12 @@ expand_kul(int authalg,
            char** out_error);
 
 /* v3_crypto.c */
+struct evp_md_st;  /* == OpenSSL EVP_MD; forward-declared to keep openssl out of this header */
+/* maps V3O_AUTH_PROTO_* to an OpenSSL digest, or NULL for unsupported protocols */
+extern const struct evp_md_st *v3_auth_md(int auth_proto);
+/* MAC truncation length in bytes (12/16/24/32/48), or a negative sentinel for unsupported protocols */
+extern int v3_auth_maclen(int auth_proto);
+
 extern int encrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const struct snmpv3info *v3);
 extern int decrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const struct snmpv3info *v3);
 

--- a/test_v3.c
+++ b/test_v3.c
@@ -8,54 +8,187 @@
  */
 #include "sqe.h"
 
-int
-main(void)
+static int n_tests = 0;
+static int success = 0;
+
+/* engine id 00 00 00 00 00 00 00 00 00 00 00 02, 12 bytes */
+static const unsigned char engine_id[] =
+    "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02";
+#define ENGINE_ID_LEN 12
+
+static void
+to_hex(char *dst, const unsigned char *buf, unsigned len)
 {
-	int success = 0;
-	int n_tests = 0;
-    char *expect;
-    char buf[64], buf2[64];
-    char *sbuf;
+    static const char h[] = "0123456789abcdef";
+    unsigned i;
+    for (i = 0; i < len; i++) {
+        dst[2 * i]     = h[(buf[i] >> 4) & 0x0f];
+        dst[2 * i + 1] = h[buf[i] & 0x0f];
+    }
+    dst[2 * len] = 0;
+}
+
+/* Known-answer test for one auth protocol: derives Ku from the password and
+ * Kul from Ku + engine id, comparing both against the expected hex strings. */
+static void
+check_kat(const char *name, int proto,
+          const char *expect_ku_hex, const char *expect_kul_hex)
+{
+    unsigned char key[64], kul[64];
+    char hex[2 * 64 + 1];
     unsigned len;
     char *err;
 
     n_tests++;
-    expect = "\x9f\xb5\xcc\x03\x81\x49\x7b\x37\x93\x52\x89\x39\xff\x78\x8d\x5d\x79\x14\x52\x11";
-    if (password_to_key(V3O_AUTH_PROTO_SHA1, "maplesyrup", strlen("maplesyrup"), buf, 64, &len, &err)) {
-        success++;
-        n_tests++;
-        if (len == 20)
-          success++;
-        else
-          fprintf(stderr, "test %d, password_to_key: len != 20\n", n_tests);
-        n_tests++;
-        if (memcmp(expect, buf, 20) == 0)
-          success++;
-        else
-          fprintf(stderr, "test %d, password_to_key: keys differ\n", n_tests);
-    } else {
-		fprintf(stderr, "test %d, password_to_key: %s\n", n_tests, err);
+    if (!password_to_key(proto, "maplesyrup", strlen("maplesyrup"),
+                         key, sizeof(key), &len, &err)) {
+        fprintf(stderr, "test %d, %s password_to_key: %s\n", n_tests, name, err);
+        return;
     }
+    success++;
+    n_tests++;
+    if (len == strlen(expect_ku_hex) / 2)
+        success++;
+    else
+        fprintf(stderr, "test %d, %s password_to_key: len %u unexpected\n", n_tests, name, len);
+    n_tests++;
+    to_hex(hex, key, len);
+    if (strcmp(hex, expect_ku_hex) == 0)
+        success++;
+    else
+        fprintf(stderr, "test %d, %s password_to_key: Ku %s != %s\n", n_tests, name, hex, expect_ku_hex);
 
     n_tests++;
-    sbuf = "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02";
-    expect = "\x66\x95\xfe\xbc\x92\x88\xe3\x62\x82\x23\x5f\xc7\x15\x1f\x12\x84\x97\xb3\x8f\x3f";
-    if (key_to_kul(V3O_AUTH_PROTO_SHA1, buf, 20, sbuf, 12, buf2, 64, &len, &err)) {
-        success++;
-        n_tests++;
-        if (len == 20)
-          success++;
-        else
-          fprintf(stderr, "test %d, localize_key: len != 20\n", n_tests);
-        n_tests++;
-        if (memcmp(expect, buf2, 20) == 0)
-          success++;
-        else
-          fprintf(stderr, "test %d, localize_key: keys differ\n", n_tests);
-    } else {
-		fprintf(stderr, "test %d, localize_key: %s\n", n_tests, err);
+    if (!key_to_kul(proto, key, len, (void *)engine_id, ENGINE_ID_LEN,
+                    kul, sizeof(kul), &len, &err)) {
+        fprintf(stderr, "test %d, %s key_to_kul: %s\n", n_tests, name, err);
+        return;
     }
+    success++;
+    n_tests++;
+    if (len == strlen(expect_kul_hex) / 2)
+        success++;
+    else
+        fprintf(stderr, "test %d, %s key_to_kul: len %u unexpected\n", n_tests, name, len);
+    n_tests++;
+    to_hex(hex, kul, len);
+    if (strcmp(hex, expect_kul_hex) == 0)
+        success++;
+    else
+        fprintf(stderr, "test %d, %s key_to_kul: Kul %s != %s\n", n_tests, name, hex, expect_kul_hex);
+}
 
-	fprintf(stderr, "%d of %d tests passed succesfully\n", success, n_tests);
+/* Regression test mirroring request_setopt.c: the localized privacy key is
+ * derived from a password with a V3O_PRIVKUL_MAXSIZE-sized buffer, so that
+ * buffer must hold a full-length digest (64 bytes for SHA-512). The value
+ * equals the corresponding key_to_kul result for the same password/engine id. */
+static void
+check_privkul(const char *name, int proto, const char *expect_kul_hex)
+{
+    unsigned char kul[V3O_AUTHKUL_MAXSIZE];
+    char hex[2 * V3O_AUTHKUL_MAXSIZE + 1];
+    unsigned len;
+    char *err;
+
+    n_tests++;
+    if (!password_to_kul(proto, "maplesyrup", strlen("maplesyrup"),
+                         (void *)engine_id, ENGINE_ID_LEN,
+                         kul, V3O_PRIVKUL_MAXSIZE, &len, &err)) {
+        fprintf(stderr, "test %d, %s password_to_kul: %s\n", n_tests, name, err);
+        return;
+    }
+    success++;
+    n_tests++;
+    to_hex(hex, kul, len);
+    if (strcmp(hex, expect_kul_hex) == 0)
+        success++;
+    else
+        fprintf(stderr, "test %d, %s privkul %s != %s\n", n_tests, name, hex, expect_kul_hex);
+}
+
+/* Exercises the v3_crypto.c hmac_message rewrite for one protocol the same way
+ * the daemon does: ber.c signs an outgoing packet (writes the MAC into the
+ * auth-param slot) and snmp.c verifies a reply (zeroes the slot, recomputes,
+ * compares). Confirms the protocol lookup, the maclen truncation (12/16/24/32/48
+ * bytes) and the buffer handling all line up, including SHA-512's 48-byte MAC. */
+static void
+check_hmac(const char *name, int proto)
+{
+    struct snmpv3info v3;
+    unsigned char msg[128];
+    unsigned char saved[64];
+    int maclen = v3_auth_maclen(proto);
+    unsigned char *ap;
+    unsigned i;
+    char *err;
+
+    memset(&v3, 0, sizeof(v3));
+    v3.auth_proto = proto;
+    if (!password_to_kul(proto, "maplesyrup", strlen("maplesyrup"),
+                         (void *)engine_id, ENGINE_ID_LEN,
+                         v3.authkul, sizeof(v3.authkul), &v3.authkul_len, &err)) {
+        n_tests++;
+        fprintf(stderr, "test %d, %s hmac setup: %s\n", n_tests, name, err);
+        return;
+    }
+    for (i = 0; i < sizeof(msg); i++)
+        msg[i] = (unsigned char)i;
+    ap = msg + 40;  /* auth-param slot somewhere inside the message */
+
+    /* sign (ber.c finalize path): hmac_message zeroes the slot, then fills it */
+    n_tests++;
+    if (hmac_message(&v3, ap, maclen, msg, sizeof(msg), ap) < 0) {
+        fprintf(stderr, "test %d, %s hmac sign failed\n", n_tests, name);
+        return;
+    }
+    success++;
+    memcpy(saved, ap, maclen);
+
+    /* verify (snmp.c response path): recompute and compare against the received MAC */
+    n_tests++;
+    if (hmac_message(&v3, ap, maclen, msg, sizeof(msg), ap) < 0) {
+        fprintf(stderr, "test %d, %s hmac verify failed\n", n_tests, name);
+        return;
+    }
+    if (memcmp(saved, ap, maclen) == 0)
+        success++;
+    else
+        fprintf(stderr, "test %d, %s hmac not reproducible\n", n_tests, name);
+}
+
+int
+main(void)
+{
+    /* Test vectors: password "maplesyrup", engine id 00..0002.
+     * SHA-1 values reproduce RFC 3414 A.2; SHA-2 values independently
+     * derived (RFC 7860 / RFC 3414 A.2 generalized). */
+    check_kat("sha1", V3O_AUTH_PROTO_SHA1,
+              "9fb5cc0381497b3793528939ff788d5d79145211",
+              "6695febc9288e36282235fc7151f128497b38f3f");
+    check_kat("sha224", V3O_AUTH_PROTO_SHA224,
+              "282a5867ee9aac639ad59df9572c7d3ac0fbc13a905b6df07dbbf00b",
+              "0bd8827c6e29f8065e08e09237f177e410f69b90e1782be682075674");
+    check_kat("sha256", V3O_AUTH_PROTO_SHA256,
+              "ab51014d1e077f6017df2b12bee5f5aa72993177e9bb569c4dff5a4ca0b4afac",
+              "8982e0e549e866db361a6b625d84cccc11162d453ee8ce3a6445c2d6776f0f8b");
+    check_kat("sha384", V3O_AUTH_PROTO_SHA384,
+              "e06eccdf2c68a06ed034723c9c26e0db3b669e1e2efed49150b55377a2e98f383c86fb836857444654b287c93f51ff64",
+              "3b298f16164a11184279d5432bf169e2d2a48307de02b3d3f7e2b4f36eb6f0455a53689a3937eea07319a633d2ccba78");
+    check_kat("sha512", V3O_AUTH_PROTO_SHA512,
+              "7e4396de5aadc77be853819b98c9406265b3a9c37cc3176569847a4e4f6fba63dd3a73d04924d31a63f95a601f9385af6be4ed1b37f87d040f7c6ed6f8d38a91",
+              "22a5a36cedfcc085807a128d7bc6c2382167ad6c0dbc5fdff856740f3d84c099ad1ea87a8db096714d9788bd544047c9021e4229ce27e4c0a69250adfcffbb0b");
+
+    /* privacy-key derivation from a password must fit a full SHA-512 digest */
+    check_privkul("sha512-privkul", V3O_AUTH_PROTO_SHA512,
+                  "22a5a36cedfcc085807a128d7bc6c2382167ad6c0dbc5fdff856740f3d84c099ad1ea87a8db096714d9788bd544047c9021e4229ce27e4c0a69250adfcffbb0b");
+
+    /* hmac_message sign/verify round-trip for every supported protocol */
+    check_hmac("sha1", V3O_AUTH_PROTO_SHA1);
+    check_hmac("sha224", V3O_AUTH_PROTO_SHA224);
+    check_hmac("sha256", V3O_AUTH_PROTO_SHA256);
+    check_hmac("sha384", V3O_AUTH_PROTO_SHA384);
+    check_hmac("sha512", V3O_AUTH_PROTO_SHA512);
+
+    fprintf(stderr, "%d of %d tests passed succesfully\n", success, n_tests);
     return success != n_tests;
 }

--- a/v3_crypto.c
+++ b/v3_crypto.c
@@ -14,6 +14,36 @@
 #include <openssl/hmac.h>
 #include <openssl/rand.h>
 
+/// @brief Map a V3O_AUTH_PROTO_* value to its OpenSSL digest
+/// @return the EVP_MD for the protocol, or NULL if unsupported
+const EVP_MD *
+v3_auth_md(int auth_proto)
+{
+    switch (auth_proto) {
+    case V3O_AUTH_PROTO_SHA1:   return EVP_sha1();
+    case V3O_AUTH_PROTO_SHA224: return EVP_sha224();
+    case V3O_AUTH_PROTO_SHA256: return EVP_sha256();
+    case V3O_AUTH_PROTO_SHA384: return EVP_sha384();
+    case V3O_AUTH_PROTO_SHA512: return EVP_sha512();
+    default:                    return NULL;
+    }
+}
+
+/// @brief MAC truncation length (msgAuthenticationParameters size) for a protocol
+/// @return the length in bytes, or -1 if the protocol is unsupported
+int
+v3_auth_maclen(int auth_proto)
+{
+    switch (auth_proto) {
+    case V3O_AUTH_PROTO_SHA1:   return 12;
+    case V3O_AUTH_PROTO_SHA224: return 16;
+    case V3O_AUTH_PROTO_SHA256: return 24;
+    case V3O_AUTH_PROTO_SHA384: return 32;
+    case V3O_AUTH_PROTO_SHA512: return 48;
+    default:                    return -1;
+    }
+}
+
 int
 hmac_message(const struct snmpv3info* v3,
              unsigned char* out,
@@ -23,30 +53,28 @@ hmac_message(const struct snmpv3info* v3,
              unsigned char* auth_param)
 {
     HMAC_CTX* ctx = NULL;
-    const EVP_MD* md = NULL;
+    const EVP_MD* md = v3_auth_md(v3->auth_proto);
+    int maclen = v3_auth_maclen(v3->auth_proto);
 
     unsigned char md_value[EVP_MAX_MD_SIZE];
     unsigned md_len = 0;
 
-    if (out_size < 12) {
-        fprintf(stderr, "bad hmac output buffer size\n");
-        errno = EINVAL;
-        return -1;
-    }
-    if (v3->auth_proto != V3O_AUTH_PROTO_SHA1) {
+    if (!md || maclen < 0) {
         fprintf(stderr, "bad auth protocol\n");
         errno = EINVAL;
         return -1;
     }
-    if (auth_param - msg + 12 >= msg_len) {
+    if (out_size < (unsigned)maclen) {
+        fprintf(stderr, "bad hmac output buffer size\n");
+        errno = EINVAL;
+        return -1;
+    }
+    if (auth_param - msg + maclen >= msg_len) {
         fprintf(stderr, "bad auth_param pointer\n");
         errno = EINVAL;
         return -1;
     }
 
-    OpenSSL_add_all_digests();
-
-    md = EVP_get_digestbyname("SHA1");
     ctx = HMAC_CTX_new();
 
     if (!HMAC_Init_ex(ctx, v3->authkul, v3->authkul_len, md, NULL)) {
@@ -54,16 +82,16 @@ hmac_message(const struct snmpv3info* v3,
         return -1;
     }
 
-    bzero(out, 12);
+    bzero(out, maclen);
     if (!HMAC_Update(ctx, msg, auth_param - msg)) {
         ERR_print_errors_fp(stderr);
         return -1;
     }
-    if (!HMAC_Update(ctx, out, 12)) {
+    if (!HMAC_Update(ctx, out, maclen)) {
         ERR_print_errors_fp(stderr);
         return -1;
     }
-    if (!HMAC_Update(ctx, auth_param + 12, msg_len - (auth_param - msg + 12))) {
+    if (!HMAC_Update(ctx, auth_param + maclen, msg_len - (auth_param - msg + maclen))) {
         ERR_print_errors_fp(stderr);
         return -1;
     }
@@ -74,7 +102,7 @@ hmac_message(const struct snmpv3info* v3,
     }
 
     HMAC_CTX_free(ctx);
-    memcpy(out, md_value, 12);
+    memcpy(out, md_value, maclen);
 
     return 0;
 }

--- a/v3_keys.c
+++ b/v3_keys.c
@@ -11,17 +11,17 @@
 #include <openssl/evp.h>
 
 static bool
-password_to_key_sha1(void *pass, unsigned paslen, void *keybuf, unsigned keybufsize, unsigned *out_keylen, char **out_error)
+password_to_key_md(const EVP_MD *md, void *pass, unsigned paslen, void *keybuf, unsigned keybufsize, unsigned *out_keylen, char **out_error)
 {
     EVP_MD_CTX *ctx;
     int cnt = 1048576;
 
     *out_error = "ok";
-    if (keybufsize < EVP_MD_size(EVP_sha1())) {
+    if (keybufsize < EVP_MD_size(md)) {
         *out_error = "insufficient buffer space";
         return false;
     }
-    *out_keylen = EVP_MD_size(EVP_sha1());
+    *out_keylen = EVP_MD_size(md);
 
     if (paslen <= 0) {
         *out_error = "empty password";
@@ -33,7 +33,7 @@ password_to_key_sha1(void *pass, unsigned paslen, void *keybuf, unsigned keybufs
         return false;
     }
 
-    if (1 != EVP_DigestInit_ex(ctx, EVP_sha1(), NULL)) {
+    if (1 != EVP_DigestInit_ex(ctx, md, NULL)) {
         *out_error = "EVP_DigestInit_ex";
         EVP_MD_CTX_free(ctx);
         return false;
@@ -61,19 +61,17 @@ password_to_key_sha1(void *pass, unsigned paslen, void *keybuf, unsigned keybufs
 bool
 password_to_key(int algorithm, void *pass, unsigned pass_size, void *keybuf, unsigned keybufsize, unsigned *out_keylen, char **out_error)
 {
-    switch (algorithm) {
-    case V3O_AUTH_PROTO_SHA1:
-        return password_to_key_sha1(pass, pass_size, keybuf, keybufsize, out_keylen, out_error);
-        break;
-    default:
+    const EVP_MD *md = v3_auth_md(algorithm);
+    if (!md) {
         *out_error = "unsupported alrgorithm";
         return false;
     }
-    return false;
+    return password_to_key_md(md, pass, pass_size, keybuf, keybufsize, out_keylen, out_error);
 }
 
 static bool
-key_to_kul_sha1(void* key,
+key_to_kul_md(const EVP_MD *md,
+                void* key,
                 unsigned key_size,
                 void* engine_id,
                 unsigned engine_id_size,
@@ -85,11 +83,11 @@ key_to_kul_sha1(void* key,
     EVP_MD_CTX *ctx;
 
     *out_error = "ok";
-    if (out_kul_size < EVP_MD_size(EVP_sha1())) {
+    if (out_kul_size < EVP_MD_size(md)) {
         *out_error = "insufficient buffer space";
         return false;
     }
-    *out_kul_len = EVP_MD_size(EVP_sha1());
+    *out_kul_len = EVP_MD_size(md);
 
     if (key_size <= 0) {
         *out_error = "empty key";
@@ -106,7 +104,7 @@ key_to_kul_sha1(void* key,
         return false;
     }
 
-    if (1 != EVP_DigestInit_ex(ctx, EVP_sha1(), NULL)) {
+    if (1 != EVP_DigestInit_ex(ctx, md, NULL)) {
         *out_error = "EVP_DigestInit_ex";
         EVP_MD_CTX_free(ctx);
         return false;
@@ -163,22 +161,20 @@ key_to_kul(int algorithm,
            unsigned* out_kul_len,
            char** out_error)
 {
-    switch (algorithm) {
-    case V3O_AUTH_PROTO_SHA1:
-        return key_to_kul_sha1(key,
-                               key_size,
-                               engine_id,
-                               engine_id_size,
-                               out_kul,
-                               out_kul_size,
-                               out_kul_len,
-                               out_error);
-        break;
-    default:
+    const EVP_MD *md = v3_auth_md(algorithm);
+    if (!md) {
         *out_error = "unsupported alrgorithm";
         return false;
     }
-    return false;
+    return key_to_kul_md(md,
+                         key,
+                         key_size,
+                         engine_id,
+                         engine_id_size,
+                         out_kul,
+                         out_kul_size,
+                         out_kul_len,
+                         out_error);
 }
 
 extern bool


### PR DESCRIPTION
## Add SNMPv3 HMAC-SHA-2 authentication (RFC 7860)

Adds the four HMAC-SHA-2 USM auth protocols alongside HMAC-SHA-1:

- usmHMAC128SHA224 (id 3): 28-byte key, 16-byte MAC
- usmHMAC192SHA256 (id 4): 32-byte key, 24-byte MAC
- usmHMAC256SHA384 (id 5): 48-byte key, 32-byte MAC
- usmHMAC384SHA512 (id 6): 64-byte key, 48-byte MAC

### What changed

- New helpers `v3_auth_md()` / `v3_auth_maclen()` (v3_crypto.c) map a protocol to its OpenSSL EVP_MD and MAC-truncation length.
- `hmac_message()` and the key routines (`password_to_key` / `key_to_kul`) are parameterized by the digest instead of hard-coding SHA-1 and the 12-byte MAC.
- Per-protocol MAC length wired through the response verifier (snmp.c) and the outgoing request builder (ber.c).
- Buffers grown for a SHA-512 localized key: V3O_AUTHKUL_MAXSIZE / V3O_PRIVKUL_MAXSIZE 32 to 64, auth-param buffers to EVP_MAX_MD_SIZE.
- setopt/getopt accept and report sha224 / sha256 / sha384 / sha512.

### Testing

- test_v3 extended with known-answer tests (Ku/Kul) for all four SHA-2 protocols, a SHA-512 privacy-key sizing regression, and an HMAC sign/verify round-trip. 42/42 pass.
- KAT vectors cross-checked against an independent RFC 3414/7860 implementation and net-snmp.