### PR TITLE
fix: BER signed integer encoding

### DIFF
--- a/ber.c
+++ b/ber.c
@@ -556,24 +556,24 @@ int
 encode_integer(unsigned i, struct ber *e, int force_size)
 {
     int l;
-    if (i <= 255)
+    if (i <= 0x7f)
         l = 1;
-    else if (i <= 65535)
+    else if (i <= 0x7fff)
         l = 2;
-    else if (i <= 16777215)
+    else if (i <= 0x7fffff)
         l = 3;
-    else if (i <= 4294967295u)
+    else if (i <= 0x7fffffff)
         l = 4;
-    else {
-        errno = ERANGE;
-        return -1;
-    }
+    else
+        l = 5;
     if (force_size)
         l = force_size;
     if (encode_type_len(AT_INTEGER, l, e) < 0)
         return -1;
     SPACECHECK(l);
     switch (l) {
+    case 5:
+        e->b[l - 5] = 0;
     case 4:
         e->b[l - 4] = (i >> 24) & 0xff;
     case 3:

--- a/ber.c
+++ b/ber.c
@@ -549,6 +549,8 @@ encode_bytes(const unsigned char *p, int n, struct ber *e)
     return 0;
 }
 
+/* With a non-zero force_size, the caller must ensure the value
+ * fits positively into force_size bytes. */
 int
 encode_integer(unsigned i, struct ber *e, int force_size)
 {

--- a/ber.c
+++ b/ber.c
@@ -414,8 +414,10 @@ finalize_snmp_packet(struct packet_builder *pb, struct ber *out_encoded_packet, 
     if (type == PDU_GET_BULK_REQUEST) {
         if (max_repetitions <= 0)
             max_repetitions = 10;
-        if (max_repetitions > 255)
-            max_repetitions = 255;
+        /* single positive BER byte: the value is patched into a fixed
+         * 1-byte integer slot, and 128..255 would read as negative */
+        if (max_repetitions > 127)
+            max_repetitions = 127;
         pb->max_repetitions[0] = (unsigned char)max_repetitions;
     }
 

--- a/ber.c
+++ b/ber.c
@@ -306,10 +306,10 @@ start_snmp_packet(struct packet_builder *pb, int version, unsigned request_id, c
         EXTEND2;
 
         /* We just set msgID to be the same as request-id in the PDU */
-        if (encode_integer(request_id, e, 0) < 0)
-            return -1;    // XXX always 4 bytes?
+        if (encode_integer(request_id, e, 4) < 0)
+            return -1;
         pb->pi.sid_offset = e->b - e->buf - 4;
-        if (encode_integer(v3->msg_max_size, e, 2) < 0)
+        if (encode_integer(v3->msg_max_size, e, 0) < 0)
             return -1;
         if (encode_bytes(&msg_flags, 1, e) < 0)
             return -1;
@@ -336,13 +336,8 @@ start_snmp_packet(struct packet_builder *pb, int version, unsigned request_id, c
 
         if (encode_integer(v3->engine_boots, e, 0) < 0)
             return -1;
-        if (v3->engine_time >= 0x800000) { // kludge, proper fix later
-            if (encode_integer(v3->engine_time, e, 4) < 0)
-                return -1;
-        } else {
-            if (encode_integer(v3->engine_time, e, 0) < 0)
-                return -1;
-        }
+        if (encode_integer(v3->engine_time, e, 0) < 0)
+            return -1;
 
         if (encode_string(v3->username, e) < 0)
             return -1;

--- a/manual.mdwn
+++ b/manual.mdwn
@@ -248,6 +248,7 @@ Supported options:
     in a single reply when requesting a table
     using SNMP 2c.  This can be overridden
     by individual GETTABLE requests.  The default is **10**.
+    The value must be between **1** and **127**.
     This is a per destination option which affects other clients.
 
 **`ignore_threshold`**

--- a/request_gettable.c
+++ b/request_gettable.c
@@ -42,7 +42,7 @@ handle_gettable_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 		max_repetitions = -1;
 		if (o->via.array.ptr[RI_GETTABLE_MREP].type == MSGPACK_OBJECT_POSITIVE_INTEGER)
 			max_repetitions = o->via.array.ptr[RI_GETTABLE_MREP].via.u64;
-		if (max_repetitions < 1 || max_repetitions > 255)
+		if (max_repetitions < 1 || max_repetitions > 127)
 			return error_reply(si, RT_GETTABLE|RT_ERROR, cid, "bad max repetitions");
 	}
 

--- a/request_setopt.c
+++ b/request_setopt.c
@@ -185,7 +185,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 			d.min_interval = v->via.u64;
 			break;
 		case OPT_max_repetitions:
-			if (t != MSGPACK_OBJECT_POSITIVE_INTEGER || v->via.u64 < 1 || v->via.u64 > 255)
+			if (t != MSGPACK_OBJECT_POSITIVE_INTEGER || v->via.u64 < 1 || v->via.u64 > 127)
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid max repetitions");
 			d.max_repetitions = v->via.u64;
 			break;

--- a/sqe.h
+++ b/sqe.h
@@ -529,6 +529,7 @@ extern size_t object_hexstring_to_buffer(msgpack_object *o, uint8_t *buf, size_t
 extern int object_string_eq(msgpack_object *o, char *s);
 extern int object2ip(msgpack_object *o, struct in_addr *ip); /* 1 = success, 0 = failure */
 extern unsigned next_sid(void);
+extern unsigned next_sid_from(unsigned cur);
 extern void dump_buf(FILE *f, void *buf, int len);
 extern char *oid2str(struct ber o);
 extern char *timestring(void);

--- a/t/queries.t
+++ b/t/queries.t
@@ -152,6 +152,8 @@ request_match("setopt bad min interval 2", [RT_SETOPT,2122,"127.0.0.1",161,{min_
 request_match("setopt bad max repetitions 1", [RT_SETOPT,2220,"127.0.0.1",161,{max_repetitions=>"foo"}], [RT_SETOPT|RT_ERROR,2220,qr/invalid max repetitions/]);
 request_match("setopt bad max repetitions 2", [RT_SETOPT,2221,"127.0.0.1",161,{max_repetitions=>0}], [RT_SETOPT|RT_ERROR,2221,qr/invalid max repetitions/]);
 request_match("setopt bad max repetitions 3", [RT_SETOPT,2222,"127.0.0.1",161,{max_repetitions=>256}], [RT_SETOPT|RT_ERROR,2222,qr/invalid max repetitions/]);
+request_match("setopt bad max repetitions 4", [RT_SETOPT,2223,"127.0.0.1",161,{max_repetitions=>128}], [RT_SETOPT|RT_ERROR,2223,qr/invalid max repetitions/]);
+request_match("gettable bad max repetitions", [RT_GETTABLE,2224,"127.0.0.1",161,"1.3.6.1.2.1.1.9.1.2",128], [RT_GETTABLE|RT_ERROR,2224,qr/bad max repetitions/]);
 request_match("defaults unchanged", [RT_SETOPT,2023,"127.0.0.1",161, {}], [RT_SETOPT|RT_REPLY,2023,
 	{ip=>"127.0.0.1", port=>161, community=>"public", version=>2, max_packets => 3, max_req_size => 1400, timeout => 2000, retries => 3, min_interval => 10, max_repetitions => 10, }]);
 request_match("change timeout", [RT_SETOPT,2024,"127.0.0.1",161, {timeout=>1500}], [RT_SETOPT|RT_REPLY,2024,

--- a/test_ber.c
+++ b/test_ber.c
@@ -185,6 +185,19 @@ test_encode_integer(int *test, unsigned value, int force_size, const char *res, 
 }
 
 int
+test_next_sid_from(int *test, unsigned cur, unsigned expected)
+{
+	unsigned got;
+
+	(*test)++;
+	if ((got = next_sid_from(cur)) != expected) {
+		fprintf(stderr, "test %d, next_sid_from(%#x): expected %#x, got %#x\n", *test, cur, expected, got);
+		return 0;
+	}
+	return 1;
+}
+
+int
 main(void)
 {
 	int success = 0;
@@ -276,6 +289,13 @@ main(void)
 	success += test_encode_integer(&n_tests, 0xffffffffu, 0, "\x02\x05\x00\xff\xff\xff\xff", 7);
 	success += test_encode_integer(&n_tests, 6789012, 4, "\x02\x04\x00\x67\x97\x94", 6);
 	success += test_encode_integer(&n_tests, 0x01020304, 4, "\x02\x04\x01\x02\x03\x04", 6);
+
+	success += test_next_sid_from(&n_tests, 0x01000000, 0x01000001);
+	success += test_next_sid_from(&n_tests, 0x01ffffff, 0x02000000);
+	success += test_next_sid_from(&n_tests, 0x7ffffffe, 0x7fffffff);
+	success += test_next_sid_from(&n_tests, 0x7fffffff, 0x01000000);
+	success += test_next_sid_from(&n_tests, 0xffffffffu, 0x01000000);
+	success += test_next_sid_from(&n_tests, 0, 0x01000001);
 
 	fprintf(stderr, "%d of %d tests passed succesfully\n", success, n_tests);
 	return success != n_tests;

--- a/test_ber.c
+++ b/test_ber.c
@@ -197,6 +197,103 @@ test_next_sid_from(int *test, unsigned cur, unsigned expected)
 	return 1;
 }
 
+static int
+buf_find(const unsigned char *hay, int hay_len, const char *needle, int needle_len)
+{
+	int i;
+	for (i = 0; i + needle_len <= hay_len; i++)
+		if (memcmp(hay + i, (const unsigned char *)needle, needle_len) == 0)
+			return 1;
+	return 0;
+}
+
+int
+test_v3_header_encoding(int *test)
+{
+	struct packet_builder pb;
+	struct snmpv3info v3;
+	struct ber *e;
+
+	(*test)++;
+	memset(&v3, 0, sizeof(v3));
+	memcpy(v3.engine_id, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02", 12);
+	v3.engine_id_len = 12;
+	strcpy(v3.username, "testuser");
+	v3.auth_proto = V3O_AUTH_PROTO_SHA1;
+	v3.priv_proto = V3O_PRIV_PROTO_AES128;
+	v3.msg_max_size = 50000;
+	v3.engine_boots = 200;
+	v3.engine_time = 40000;
+
+	if (start_snmp_packet(&pb, 3, 0x01020304, &v3, NULL) < 0) {
+		fprintf(stderr, "test %d, v3 header: start_snmp_packet unexpected failure\n", *test);
+		return 0;
+	}
+	e = &pb.e;
+	if (!buf_find(e->buf, e->len, "\x02\x03\x00\xc3\x50", 5)) {
+		fprintf(stderr, "test %d, v3 header: msgMaxSize 50000 not encoded as 02 03 00 c3 50\n", *test);
+		free(e->buf);
+		return 0;
+	}
+	if (!buf_find(e->buf, e->len, "\x02\x02\x00\xc8", 4)) {
+		fprintf(stderr, "test %d, v3 header: engine boots 200 not encoded as 02 02 00 c8\n", *test);
+		free(e->buf);
+		return 0;
+	}
+	if (!buf_find(e->buf, e->len, "\x02\x03\x00\x9c\x40", 5)) {
+		fprintf(stderr, "test %d, v3 header: engine time 40000 not encoded as 02 03 00 9c 40\n", *test);
+		free(e->buf);
+		return 0;
+	}
+	if (memcmp(e->buf + pb.pi.sid_offset, "\x01\x02\x03\x04", 4) != 0) {
+		fprintf(stderr, "test %d, v3 header: sid_offset does not point at msgID bytes\n", *test);
+		free(e->buf);
+		return 0;
+	}
+	free(e->buf);
+	return 1;
+}
+
+int
+test_v2c_getbulk_packet(int *test, int max_repetitions, const char *mrep_tlv)
+{
+	struct packet_builder pb;
+	struct packet_info pi;
+	struct ber packet;
+	char oidbuf[64];
+	struct ber oid = ber_init(oidbuf, 64);
+
+	(*test)++;
+	if (encode_string_oid("1.3.6.1.2.1.1.9.1.2", -1, &oid) < 0) {
+		fprintf(stderr, "test %d, getbulk: cannot encode test oid\n", *test);
+		return 0;
+	}
+	if (start_snmp_packet(&pb, 1, 0x01020304, NULL, "public") < 0) {
+		fprintf(stderr, "test %d, getbulk: start_snmp_packet unexpected failure\n", *test);
+		return 0;
+	}
+	if (add_encoded_oid_to_snmp_packet(&pb, &oid) < 0) {
+		fprintf(stderr, "test %d, getbulk: add_encoded_oid_to_snmp_packet unexpected failure\n", *test);
+		return 0;
+	}
+	if (finalize_snmp_packet(&pb, &packet, NULL, &pi, PDU_GET_BULK_REQUEST, max_repetitions) < 0) {
+		fprintf(stderr, "test %d, getbulk: finalize_snmp_packet unexpected failure\n", *test);
+		return 0;
+	}
+	if (!buf_find(packet.buf, packet.len, mrep_tlv, 3)) {
+		fprintf(stderr, "test %d, getbulk(%d): expected max-repetitions TLV not found\n", *test, max_repetitions);
+		free(packet.buf);
+		return 0;
+	}
+	if (memcmp(packet.buf + pi.sid_offset, "\x01\x02\x03\x04", 4) != 0) {
+		fprintf(stderr, "test %d, getbulk: sid_offset does not point at request-id bytes\n", *test);
+		free(packet.buf);
+		return 0;
+	}
+	free(packet.buf);
+	return 1;
+}
+
 int
 main(void)
 {
@@ -296,6 +393,9 @@ main(void)
 	success += test_next_sid_from(&n_tests, 0x7fffffff, 0x01000000);
 	success += test_next_sid_from(&n_tests, 0xffffffffu, 0x01000000);
 	success += test_next_sid_from(&n_tests, 0, 0x01000001);
+
+	success += test_v3_header_encoding(&n_tests);
+	success += test_v2c_getbulk_packet(&n_tests, 100, "\x02\x01\x64");
 
 	fprintf(stderr, "%d of %d tests passed succesfully\n", success, n_tests);
 	return success != n_tests;

--- a/test_ber.c
+++ b/test_ber.c
@@ -153,6 +153,38 @@ test_oid_compare(int *test, const char *o1, const char *o2, int expected)
 }
 
 int
+test_encode_integer(int *test, unsigned value, int force_size, const char *res, int len)
+{
+	unsigned char buf[16];
+	struct ber e = ber_init(buf, 16);
+	unsigned decoded;
+
+	(*test)++;
+	if (encode_integer(value, &e, force_size) < 0) {
+		fprintf(stderr, "test %d, encode_integer(%u,%d): unexpected failure\n", *test, value, force_size);
+		return 0;
+	}
+	if (e.len != len) {
+		fprintf(stderr, "test %d, encode_integer(%u,%d): unexpected length (%d != %d)\n", *test, value, force_size, e.len, len);
+		return 0;
+	}
+	if (memcmp(buf, res, len) != 0) {
+		fprintf(stderr, "test %d, encode_integer(%u,%d): unexpected buffer content\n", *test, value, force_size);
+		return 0;
+	}
+	e = ber_init(buf, len);
+	if (decode_integer(&e, -1, &decoded) < 0) {
+		fprintf(stderr, "test %d, encode_integer(%u,%d): cannot decode encoded integer\n", *test, value, force_size);
+		return 0;
+	}
+	if (decoded != value) {
+		fprintf(stderr, "test %d, encode_integer(%u,%d): decode round-trip gave %u\n", *test, value, force_size, decoded);
+		return 0;
+	}
+	return 1;
+}
+
+int
 main(void)
 {
 	int success = 0;
@@ -226,22 +258,26 @@ main(void)
 		"1.3.6.1.4.1.6527.3.1.2.4.3.7.1.12.10000745.35946496.1519.1",
 		0);
 
-	fprintf(stderr, "%d of %d tests passed succesfully\n", success, n_tests);
+	success += test_encode_integer(&n_tests, 0, 0, "\x02\x01\x00", 3);
+	success += test_encode_integer(&n_tests, 127, 0, "\x02\x01\x7f", 3);
+	success += test_encode_integer(&n_tests, 128, 0, "\x02\x02\x00\x80", 4);
+	success += test_encode_integer(&n_tests, 255, 0, "\x02\x02\x00\xff", 4);
+	success += test_encode_integer(&n_tests, 256, 0, "\x02\x02\x01\x00", 4);
+	success += test_encode_integer(&n_tests, 32767, 0, "\x02\x02\x7f\xff", 4);
+	success += test_encode_integer(&n_tests, 32768, 0, "\x02\x03\x00\x80\x00", 5);
+	success += test_encode_integer(&n_tests, 65507, 0, "\x02\x03\x00\xff\xe3", 5);
+	success += test_encode_integer(&n_tests, 65535, 0, "\x02\x03\x00\xff\xff", 5);
+	success += test_encode_integer(&n_tests, 65536, 0, "\x02\x03\x01\x00\x00", 5);
+	success += test_encode_integer(&n_tests, 0x7fffff, 0, "\x02\x03\x7f\xff\xff", 5);
+	success += test_encode_integer(&n_tests, 0x800000, 0, "\x02\x04\x00\x80\x00\x00", 6);
+	success += test_encode_integer(&n_tests, 0x1000000, 0, "\x02\x04\x01\x00\x00\x00", 6);
+	success += test_encode_integer(&n_tests, 0x7fffffff, 0, "\x02\x04\x7f\xff\xff\xff", 6);
+	success += test_encode_integer(&n_tests, 0x80000000u, 0, "\x02\x05\x00\x80\x00\x00\x00", 7);
+	success += test_encode_integer(&n_tests, 0xffffffffu, 0, "\x02\x05\x00\xff\xff\xff\xff", 7);
+	success += test_encode_integer(&n_tests, 6789012, 4, "\x02\x04\x00\x67\x97\x94", 6);
+	success += test_encode_integer(&n_tests, 0x01020304, 4, "\x02\x04\x01\x02\x03\x04", 6);
 
-	{
-		struct ber e;
-		char buf[1500];
-		e = ber_init(buf, 1500);
-		if (build_get_request_packet(1, "public",
-			"1.3.6.1.2.1.2.2.1.2.1001\0"
-			"1.3.6.1.2.1.2.2.1.2.25\0",
-			6789012, &e) < 0)
-		{
-			perror("build_get_request_packet");
-		} else {
-			ber_dump(stderr, &e);
-		}
-	}
-	return 0;
+	fprintf(stderr, "%d of %d tests passed succesfully\n", success, n_tests);
+	return success != n_tests;
 }
 

--- a/test_ber.c
+++ b/test_ber.c
@@ -396,6 +396,7 @@ main(void)
 
 	success += test_v3_header_encoding(&n_tests);
 	success += test_v2c_getbulk_packet(&n_tests, 100, "\x02\x01\x64");
+	success += test_v2c_getbulk_packet(&n_tests, 200, "\x02\x01\x7f");
 
 	fprintf(stderr, "%d of %d tests passed succesfully\n", success, n_tests);
 	return success != n_tests;

--- a/util.c
+++ b/util.c
@@ -150,8 +150,8 @@ next_sid_from(unsigned cur)
 	if ((cur & 0x80000000) != 0) {
 		/* Wrapped past 0x7fffffff, reset to start of range */
 		cur = 0x01000000;
-	} else if ((cur & 0x7f000000) == 0) {
-		/* Below 0x01000000, set bit 24 to enter range */
+	} else if (cur < 0x01000000) {
+		/* Below the range, set bit 24 to enter it */
 		cur |= 0x01000000;
 	}
 	/* Request ids stay in [0x01000000, 0x7fffffff]: the minimal BER

--- a/util.c
+++ b/util.c
@@ -144,6 +144,23 @@ static int sid_initialized = 0;
 static unsigned sid;
 
 unsigned
+next_sid_from(unsigned cur)
+{
+	cur++;
+	if ((cur & 0x80000000) != 0) {
+		/* Wrapped past 0x7fffffff, reset to start of range */
+		cur = 0x01000000;
+	} else if ((cur & 0x7f000000) == 0) {
+		/* Below 0x01000000, set bit 24 to enter range */
+		cur |= 0x01000000;
+	}
+	/* Request ids stay in [0x01000000, 0x7fffffff]: the minimal BER
+	 * encoding is then always exactly 4 positive bytes, which the
+	 * in-place sid patching of built packets relies upon. */
+	return cur;
+}
+
+unsigned
 next_sid(void)
 {
 	struct timeval tv;
@@ -153,12 +170,7 @@ next_sid(void)
 		gettimeofday(&tv, NULL);
 		sid = (tv.tv_sec % 500009) + tv.tv_usec;
 	}
-	sid++;
-	sid &= 0xffffffff;
-	if (sid == 0)
-		sid++;
-	// hack to make sure it will be coded as 4 bytes while being DER
-	sid |= 0x01000000;
+	sid = next_sid_from(sid);
 	return sid;
 }
 


### PR DESCRIPTION
BER INTEGER is signed two's-complement, but encode_integer() picked encoding
lengths by unsigned magnitude, so any value whose leading content byte had the
top bit set (128, 65507, sids >= 0x80000000, ...) went out on the wire as a
negative number. Devices either reject such packets or echo the id back in a
short canonical form that SQE then fails to match (see the net-snmp-coders
thread on msgMaxSize 65507 being encoded as 02 03 00 ff e3).

- encode_integer(): signed-correct minimal lengths, up to 5 bytes with a
  leading 0x00 for values >= 0x80000000
- next_sid(): request ids capped to [0x01000000, 0x7fffffff] so the forced
  4-byte request-id/msgID encoding is always positive (extracted pure
  next_sid_from() for testability)
- v3 header: msgMaxSize no longer force-encoded in 2 bytes (was negative for
  values >= 32768); engine-time >= 0x800000 kludge removed (dead code now);
  msgID width made explicitly 4 bytes to match sid_offset patching
- GETBULK max-repetitions clamped/validated to 1..127 (it is patched into a
  fixed 1-byte slot; 128..255 encoded negative, which RFC 3416 treats as 0)
- test_ber now exits non-zero on failure and drops the leftover demo packet
  dump

Test plan:
- [x] test_ber: encode_integer boundary cases incl. 65507, decode round-trips,
      next_sid_from wrap, v3 header packet-shape, GETBULK clamp
- [x] test_v3, test_msgpack, prove t/queries.t all green
- [x] queries.t: setopt/gettable reject max_repetitions 128