### PR TITLE
test: cover table-walk termination on non-increasing OID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ test_msgpack
 test_msgpack.dSYM/
 test_v3
 test_v3.dSYM/
+test_sid_info
+test_sid_info.dSYM/
 *.o
 .*.swp
 snmp-query-engine

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ INCPATH=	-I/usr/local/include -I/opt/local/include -I/opt/homebrew/include
 LIBPATH=	-L/usr/local/lib -L/opt/local/lib -L/opt/homebrew/lib
 CFLAGS=	-Wall -Wno-unused-function -Wno-deprecated-declarations -Werror $(OPTIMIZE) $(INCPATH)
 
-all: snmp-query-engine test_ber test_msgpack test_v3
+all: snmp-query-engine test_ber test_msgpack test_v3 test_sid_info
 
 STDOBJ=event_loop.o carp.o client_input.o client_listen.o opts.o util.o destination.o \
 	client_requests_info.o cid_info.o ber.o oid_info.o sid_info.o \
@@ -23,7 +23,7 @@ STDOBJ=event_loop.o carp.o client_input.o client_listen.o opts.o util.o destinat
 STDLINK=$(STDOBJ) $(LIBPATH) -lJudy -lmsgpackc -lcrypto
 
 clean:
-	rm -f *.o snmp-query-engine test_ber test_msgpack test_v3 *.core core
+	rm -f *.o snmp-query-engine test_ber test_msgpack test_v3 test_sid_info *.core core
 
 snmp-query-engine: main.o $(STDOBJ)
 	$(CC) $(CFLAGS) -o snmp-query-engine main.o $(STDLINK)
@@ -105,6 +105,9 @@ test_msgpack: test_msgpack.c $(STDOBJ)
 
 test_v3: test_v3.c $(STDOBJ)
 	$(CC) $(CFLAGS) -o test_v3 test_v3.c $(STDLINK)
+
+test_sid_info: test_sid_info.c $(STDOBJ)
+	$(CC) $(CFLAGS) -o test_sid_info test_sid_info.c $(STDLINK)
 
 test: snmp-query-engine
 	prove t/queries.t

--- a/test_sid_info.c
+++ b/test_sid_info.c
@@ -1,0 +1,162 @@
+/*
+ * Part of `snmp-query-engine`.
+ *
+ * Copyright 2025, Anton Berezin <tobez@tobez.org>
+ * Modified BSD license.
+ * (See LICENSE file in the distribution.)
+ *
+ */
+/* ABOUTME: Tests that a table walk terminates when a device returns a
+ * ABOUTME: non-increasing (repeated or smaller) OID, per PR #8. */
+#include "sqe.h"
+
+static int n_tests = 0;
+static int success = 0;
+
+static void
+check(const char *name, int ok)
+{
+	n_tests++;
+	if (ok) {
+		success++;
+	} else {
+		fprintf(stderr, "test %d, %s: FAILED\n", n_tests, name);
+	}
+}
+
+/* Encode an OID string into a freshly allocated BER, shaped like the OID
+ * bers produced by decode_oid() (buf points at the type byte, max_len
+ * covers the whole TLV). */
+static struct ber
+make_oid(const char *s)
+{
+	unsigned char tmp[256];
+	struct ber e = ber_init(tmp, sizeof tmp);
+
+	if (encode_string_oid(s, -1, &e) < 0)
+		croak(2, "make_oid: encode_string_oid(%s)", s);
+	return ber_dup(&e);
+}
+
+/* Build the tail of a GET-RESPONSE that process_sid_info_response() expects:
+ * error-status, error-index, then a varbind list holding a single
+ * { OID, INTEGER } binding for the given table entry OID. */
+static struct ber
+make_response(const char *entry_oid)
+{
+	static unsigned char buf[512];
+	struct ber e = ber_init(buf, sizeof buf);
+	unsigned char *varbind_list, *varbind;
+
+	bzero(buf, sizeof buf);
+	if (encode_integer(0, &e, 0) < 0)      /* error-status */
+		croak(2, "make_response: error-status");
+	if (encode_integer(0, &e, 0) < 0)      /* error-index */
+		croak(2, "make_response: error-index");
+
+	varbind_list = e.b;
+	if (encode_type_len(AT_SEQUENCE, 0, &e) < 0)
+		croak(2, "make_response: varbind list");
+	varbind = e.b;
+	if (encode_type_len(AT_SEQUENCE, 0, &e) < 0)
+		croak(2, "make_response: varbind");
+	if (encode_string_oid(entry_oid, -1, &e) < 0)
+		croak(2, "make_response: oid");
+	if (encode_integer(42, &e, 0) < 0)     /* value */
+		croak(2, "make_response: value");
+	encode_store_length(&e, varbind);
+	encode_store_length(&e, varbind_list);
+
+	return ber_rewind(e);
+}
+
+/* Drive one response OID through a table walk whose last known entry is
+ * last_known, and report how much oids_non_increasing moved. */
+static void
+run_case(const char *name, const char *table_base, const char *last_known,
+         const char *response_entry, int64_t expected_delta)
+{
+	struct destination dest;
+	struct socket_info sock;
+	struct client_requests_info cri;
+	struct cid_info *ci;
+	struct oid_info last_oi;
+	struct oid_info *table_oid;
+	struct sid_info si;
+	struct ber resp;
+	int64_t before, delta;
+	int rc;
+	unsigned cid = 100;
+
+	bzero(&dest, sizeof dest);
+	dest.max_repetitions = 10;
+
+	bzero(&sock, sizeof sock);
+	TAILQ_INIT(&sock.send_bufs);
+
+	bzero(&cri, sizeof cri);
+	cri.dest = &dest;
+	cri.si = &sock;
+	cri.fd = 7;
+	cri.version = 2;
+	TAILQ_INIT(&cri.oids_to_query);
+	TAILQ_INIT(&cri.sid_infos);
+
+	ci = get_cid_info(&cri, cid);
+	/* Pretend a second OID for this client request is still outstanding so
+	 * the end-of-walk cid_reply() (which needs the event loop) never fires;
+	 * we assert on the non-increasing counter, not on the client reply. */
+	ci->n_oids = 2;
+	ci->n_oids_being_queried = 1;
+	ci->n_oids_done = 0;
+
+	bzero(&last_oi, sizeof last_oi);
+	last_oi.oid = make_oid(last_known);
+
+	table_oid = malloc(sizeof *table_oid);
+	if (!table_oid)
+		croak(2, "run_case: malloc(table_oid)");
+	bzero(table_oid, sizeof *table_oid);
+	table_oid->cid = cid;
+	table_oid->fd = cri.fd;
+	table_oid->oid = make_oid(table_base);
+	table_oid->last_known_table_entry = &last_oi;
+	table_oid->max_repetitions = 10;
+
+	bzero(&si, sizeof si);
+	si.cri = &cri;
+	si.sid = 55;
+	si.version = 2;
+	si.table_oid = table_oid;
+	TAILQ_INIT(&si.oids_being_queried);
+
+	resp = make_response(response_entry);
+
+	before = PS.oids_non_increasing;
+	rc = process_sid_info_response(&si, &resp);
+	delta = PS.oids_non_increasing - before;
+
+	check(name, rc == 1 && delta == expected_delta);
+}
+
+int
+main(void)
+{
+	const char *base = "1.3.6.1.2.1.2.2.1.2";
+
+	/* A device that repeats the same OID must be treated as non-increasing
+	 * so the walk terminates instead of looping forever. */
+	run_case("repeated oid terminates walk",
+	         base, "1.3.6.1.2.1.2.2.1.2.1", "1.3.6.1.2.1.2.2.1.2.1", 1);
+
+	/* A strictly larger OID is a normal table advance, not non-increasing. */
+	run_case("increasing oid continues walk",
+	         base, "1.3.6.1.2.1.2.2.1.2.1", "1.3.6.1.2.1.2.2.1.2.2", 0);
+
+	/* A smaller OID is non-increasing, terminating the walk. */
+	run_case("smaller oid terminates walk",
+	         base, "1.3.6.1.2.1.2.2.1.2.2", "1.3.6.1.2.1.2.2.1.2.1", 1);
+
+	fprintf(stderr, "%d of %d tests passed succesfully\n", success, n_tests);
+	return success != n_tests;
+}


### PR DESCRIPTION
Adds a `test_sid_info.c` C harness (in the `test_ber`/`test_v3` style) regression-testing the behavior fixed by #8: a table walk must terminate when a device returns a repeated or smaller OID.

Hermetic — builds a minimal `sid_info`/`table_oid` graph and a hand-encoded GET-RESPONSE, drives `process_sid_info_response()`, and asserts `oids_non_increasing` across three cases (repeated → terminate, larger → continue, smaller → terminate). No network, no live snmpd, no event loop.

## Test plan

- [x] `make && ./test_sid_info` → 3 of 3 tests pass
- [x] Full C suite green (`test_ber` 41/41, `test_v3` 42/42, `test_msgpack` exit 0)
- [x] `t/queries.t` failing set identical to master baseline (15 pre-existing environmental ignore/throttle cases; no regressions)