### PR TITLE
Adopt changie-managed changelogs and semantic versioning

### DIFF
--- a/.changes/header.tpl.md
+++ b/.changes/header.tpl.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/.changes/unreleased/Added-20260702-193924.yaml
+++ b/.changes/unreleased/Added-20260702-193924.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: changie-managed changelog
+time: 2026-07-02T19:39:24.365906+02:00

--- a/.changes/unreleased/Added-20260702-193926.yaml
+++ b/.changes/unreleased/Added-20260702-193926.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: -v command-line flag prints the program version
+time: 2026-07-02T19:39:26.428277+02:00

--- a/.changes/unreleased/Added-20260702-193927.yaml
+++ b/.changes/unreleased/Added-20260702-193927.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'INFO: new version stat with the engine version string'
+time: 2026-07-02T19:39:27.461448+02:00

--- a/.changes/unreleased/Changed-20260702-193925.yaml
+++ b/.changes/unreleased/Changed-20260702-193925.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: switch to semantic versioning; program_version stat is frozen
+time: 2026-07-02T19:39:25.39747+02:00

--- a/.changes/v0.1.0.md
+++ b/.changes/v0.1.0.md
@@ -1,0 +1,13 @@
+## [v0.1.0] - 2012-05-18
+
+### Added
+
+- multiplexing SNMP query daemon: many clients over TCP, MessagePack-encoded requests and replies
+- GET, GETTABLE, SETOPT, GETOPT, and INFO request types
+- SNMP v1 and v2c support
+- kqueue (FreeBSD/macOS) and epoll (Linux) event loops
+- per-destination throttling, retries, timeouts, and min-interval pacing
+- engine and per-connection statistics via the INFO request
+- destination, connection, and request dumping for diagnostics
+- value types: integers, strings, OIDs of any size, Counter32/Counter64, Gauge32, TimeTicks, IPv4 addresses
+- beginnings of the manual

--- a/.changes/v0.2.0.md
+++ b/.changes/v0.2.0.md
@@ -1,0 +1,13 @@
+## [v0.2.0] - 2012-08-31
+
+### Added
+
+- per-destination and per-client option settings
+- destinations are ignored for a while after repeated hard timeouts (ignore_threshold, ignore_duration)
+- destination unclogging when replies stop coming
+- README with acknowledgements
+
+### Fixed
+
+- the table OID itself is never reported as part of the table in GETTABLE
+- edge cases in the destination ignore mechanism

--- a/.changes/v0.3.0.md
+++ b/.changes/v0.3.0.md
@@ -1,0 +1,14 @@
+## [v0.3.0] - 2012-12-14
+
+### Added
+
+- OIDs as returned values
+
+### Fixed
+
+- GETTABLE terminates when the result contains a non-increasing OID
+- INTEGER32 values are treated as signed
+- potential buffer overrun when decoding string OIDs
+- OID comparison correctness, with tests
+- packets-on-the-wire counter leak when flushing a destination
+- decoding of negative BER-encoded integers

--- a/.changes/v0.4.0.md
+++ b/.changes/v0.4.0.md
@@ -1,0 +1,7 @@
+## [v0.4.0] - 2013-07-22
+
+### Added
+
+- global throttling across all destinations
+- udp_receive_buffer_size global statistic and a larger UDP receive buffer
+- program_version global statistic

--- a/.changes/v0.4.1.md
+++ b/.changes/v0.4.1.md
@@ -1,0 +1,5 @@
+## [v0.4.1] - 2013-07-26
+
+### Fixed
+
+- all pending SNMP packets are received and processed before polling again

--- a/.changes/v0.4.2.md
+++ b/.changes/v0.4.2.md
@@ -1,0 +1,5 @@
+## [v0.4.2] - 2013-07-29
+
+### Fixed
+
+- SNMP error-status in replies is taken into account

--- a/.changes/v0.5.0.md
+++ b/.changes/v0.5.0.md
@@ -1,0 +1,5 @@
+## [v0.5.0] - 2013-10-01
+
+### Added
+
+- protection against UDP send buffer overflows, with the udp_send_buffer_overflow statistic

--- a/.changes/v0.6.0.md
+++ b/.changes/v0.6.0.md
@@ -1,0 +1,5 @@
+## [v0.6.0] - 2014-05-01
+
+### Added
+
+- DEST_INFO request for per-destination statistics

--- a/.changes/v0.6.1.md
+++ b/.changes/v0.6.1.md
@@ -1,0 +1,5 @@
+## [v0.6.1] - 2014-05-23
+
+### Fixed
+
+- malformed SNMP responses no longer confuse reply matching

--- a/.changes/v0.7.0.md
+++ b/.changes/v0.7.0.md
@@ -1,0 +1,17 @@
+## [v0.7.0] - 2018-11-23
+
+### Added
+
+- client input accepted with both BIN and STR msgpack types (thanks to Dmitry Karasik)
+
+### Changed
+
+- builds with modern libmsgpack-c
+
+### Removed
+
+- support for libmsgpack-c older than 0.6
+
+### Fixed
+
+- unsigned 32-bit values that fit in 4 octets are encoded in 4 octets

--- a/.changes/v1.0.0.md
+++ b/.changes/v1.0.0.md
@@ -1,0 +1,15 @@
+## [v1.0.0] - 2023-08-22
+
+### Added
+
+- SNMPv3 support: USM authentication (SHA-1), privacy (AES and DES), engine discovery, per-destination v3 options
+- more useful logging of received packets and late replies
+
+### Changed
+
+- consistent code formatting rules for the project
+
+### Fixed
+
+- SNMP version range check
+- privacy key expansion when the key is given directly instead of via a password

--- a/.changes/v1.0.1.md
+++ b/.changes/v1.0.1.md
@@ -1,0 +1,10 @@
+## [v1.0.1] - 2023-11-10
+
+### Changed
+
+- larger client command buffer, with debug output for failing SETOPT requests
+- quieter logging of replies outside the SNMPv3 time window
+
+### Fixed
+
+- engine time is not encoded in 3 bytes, for compatibility with some devices

--- a/.changes/v1.1.0.md
+++ b/.changes/v1.1.0.md
@@ -1,0 +1,13 @@
+## [v1.1.0] - 2026-07-02
+
+### Added
+
+- SNMPv3 HMAC-SHA-2 authentication: SHA-224, SHA-256, SHA-384, SHA-512
+
+### Fixed
+
+- table walks terminate when a device repeatedly returns the same or a decreasing OID (thanks to Dmitry Karasik)
+- BER integers are encoded with correct signed lengths
+- request ids stay within the positive 4-byte BER range
+- SNMPv3 msgMaxSize is encoded with correct length
+- GETBULK max-repetitions is clamped to 127

--- a/.changie.yaml
+++ b/.changie.yaml
@@ -1,0 +1,35 @@
+changesDir: .changes
+unreleasedDir: unreleased
+headerPath: header.tpl.md
+changelogPath: CHANGELOG.md
+versionExt: md
+versionFormat: '## [{{.Version}}] - {{.Time.Format "2006-01-02"}}'
+kindFormat: '### {{.Kind}}'
+changeFormat: '- {{.Body}}'
+kinds:
+  - label: Added
+    auto: minor
+  - label: Changed
+    auto: minor
+  - label: Deprecated
+    auto: minor
+  - label: Removed
+    auto: minor
+  - label: Fixed
+    auto: patch
+  - label: Security
+    auto: patch
+newlines:
+  afterChangelogHeader: 1
+  afterChangelogVersion: 1
+  endOfVersion: 1
+  beforeKind: 1
+  afterKind: 1
+envPrefix: CHANGIE_
+replacements:
+  - path: sqe.h
+    find: '^#define SQE_VERSION "[^"]*"'
+    replace: '#define SQE_VERSION "{{.VersionNoPrefix}}"'
+  - path: manual.mdwn
+    find: '^This document describes snmp-query-engine version .*\.$'
+    replace: 'This document describes snmp-query-engine version {{.VersionNoPrefix}}.'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,147 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.1.0] - 2026-07-02
+
+### Added
+
+- SNMPv3 HMAC-SHA-2 authentication: SHA-224, SHA-256, SHA-384, SHA-512
+
+### Fixed
+
+- table walks terminate when a device repeatedly returns the same or a decreasing OID (thanks to Dmitry Karasik)
+- BER integers are encoded with correct signed lengths
+- request ids stay within the positive 4-byte BER range
+- SNMPv3 msgMaxSize is encoded with correct length
+- GETBULK max-repetitions is clamped to 127
+
+## [v1.0.1] - 2023-11-10
+
+### Changed
+
+- larger client command buffer, with debug output for failing SETOPT requests
+- quieter logging of replies outside the SNMPv3 time window
+
+### Fixed
+
+- engine time is not encoded in 3 bytes, for compatibility with some devices
+
+## [v1.0.0] - 2023-08-22
+
+### Added
+
+- SNMPv3 support: USM authentication (SHA-1), privacy (AES and DES), engine discovery, per-destination v3 options
+- more useful logging of received packets and late replies
+
+### Changed
+
+- consistent code formatting rules for the project
+
+### Fixed
+
+- SNMP version range check
+- privacy key expansion when the key is given directly instead of via a password
+
+## [v0.7.0] - 2018-11-23
+
+### Added
+
+- client input accepted with both BIN and STR msgpack types (thanks to Dmitry Karasik)
+
+### Changed
+
+- builds with modern libmsgpack-c
+
+### Removed
+
+- support for libmsgpack-c older than 0.6
+
+### Fixed
+
+- unsigned 32-bit values that fit in 4 octets are encoded in 4 octets
+
+## [v0.6.1] - 2014-05-23
+
+### Fixed
+
+- malformed SNMP responses no longer confuse reply matching
+
+## [v0.6.0] - 2014-05-01
+
+### Added
+
+- DEST_INFO request for per-destination statistics
+
+## [v0.5.0] - 2013-10-01
+
+### Added
+
+- protection against UDP send buffer overflows, with the udp_send_buffer_overflow statistic
+
+## [v0.4.2] - 2013-07-29
+
+### Fixed
+
+- SNMP error-status in replies is taken into account
+
+## [v0.4.1] - 2013-07-26
+
+### Fixed
+
+- all pending SNMP packets are received and processed before polling again
+
+## [v0.4.0] - 2013-07-22
+
+### Added
+
+- global throttling across all destinations
+- udp_receive_buffer_size global statistic and a larger UDP receive buffer
+- program_version global statistic
+
+## [v0.3.0] - 2012-12-14
+
+### Added
+
+- OIDs as returned values
+
+### Fixed
+
+- GETTABLE terminates when the result contains a non-increasing OID
+- INTEGER32 values are treated as signed
+- potential buffer overrun when decoding string OIDs
+- OID comparison correctness, with tests
+- packets-on-the-wire counter leak when flushing a destination
+- decoding of negative BER-encoded integers
+
+## [v0.2.0] - 2012-08-31
+
+### Added
+
+- per-destination and per-client option settings
+- destinations are ignored for a while after repeated hard timeouts (ignore_threshold, ignore_duration)
+- destination unclogging when replies stop coming
+- README with acknowledgements
+
+### Fixed
+
+- the table OID itself is never reported as part of the table in GETTABLE
+- edge cases in the destination ignore mechanism
+
+## [v0.1.0] - 2012-05-18
+
+### Added
+
+- multiplexing SNMP query daemon: many clients over TCP, MessagePack-encoded requests and replies
+- GET, GETTABLE, SETOPT, GETOPT, and INFO request types
+- SNMP v1 and v2c support
+- kqueue (FreeBSD/macOS) and epoll (Linux) event loops
+- per-destination throttling, retries, timeouts, and min-interval pacing
+- engine and per-connection statistics via the INFO request
+- destination, connection, and request dumping for diagnostics
+- value types: integers, strings, OIDs of any size, Counter32/Counter64, Gauge32, TimeTicks, IPv4 addresses
+- beginnings of the manual
+

--- a/main.c
+++ b/main.c
@@ -26,6 +26,7 @@ usage(char *err)
 		fprintf(f, "\t\t\tSend HUP signal to reopen the logfile\n");
 	}
 	fprintf(f, "\t-q\t\tquiet operation\n");
+	fprintf(f, "\t-v\t\tprint program version and quit\n");
 	exit(err ? 1 : 0);
 }
 
@@ -38,9 +39,9 @@ main(int argc, char **argv)
 	gettimeofday(&prog_start, NULL);
 	bzero(&PS, sizeof(PS));
 	PS.max_packets_on_the_wire = 1000000;
-	PS.program_version = 2023082200;
+	PS.program_version = 2023082200; /* frozen for protocol compatibility; see SQE_VERSION */
 
-	while ( (o = getopt(argc, argv, "hp:q")) != -1) {
+	while ( (o = getopt(argc, argv, "hp:qv")) != -1) {
 		switch (o) {
 		case 'h':
 			usage(NULL);
@@ -51,6 +52,9 @@ main(int argc, char **argv)
 		case 'q':
 			opt_quiet = 1;
 			break;
+		case 'v':
+			printf("%s %s\n", thisprogname(), SQE_VERSION);
+			exit(0);
 		default:
 			usage("");
 		}

--- a/main.c
+++ b/main.c
@@ -53,7 +53,7 @@ main(int argc, char **argv)
 			opt_quiet = 1;
 			break;
 		case 'v':
-			printf("%s %s\n", thisprogname(), SQE_VERSION);
+			printf("snmp-query-engine %s\n", SQE_VERSION);
 			exit(0);
 		default:
 			usage("");

--- a/manual.mdwn
+++ b/manual.mdwn
@@ -557,7 +557,12 @@ The following *global* statistics are available:
 :   daemon uptime in milliseconds
 
 **`program_version`**
-:   version of the engine program
+:   numeric version of the engine program
+    (frozen; see **`version`**)
+
+**`version`**
+:   version of the engine program, as a semantic versioning string
+    (present in global stats only)
 
 
 ## GET

--- a/manual.mdwn
+++ b/manual.mdwn
@@ -8,7 +8,7 @@ snmp-query-engine - multiplexing SNMP query engine
 
 # VERSION
 
-This document describes snmp-query-engine version 2023053100.
+This document describes snmp-query-engine version 1.1.0.
 
 # SYNOPSIS
 
@@ -40,6 +40,9 @@ http://msgpack.org/.
 
 -q
 :   quiet operation
+
+-v
+:   print program version and quit
 
 # REQUESTS
 

--- a/request_info.c
+++ b/request_info.c
@@ -123,8 +123,9 @@ handle_info_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 	l = strlen(key);
 	msgpack_pack_bin(pk, l);
 	msgpack_pack_bin_body(pk, key, l);
-	msgpack_pack_map(pk, pack_stats(&PS, NULL));
+	msgpack_pack_map(pk, pack_stats(&PS, NULL) + 1);
 	pack_stats(&PS, pk);
+	msgpack_pack_named_string(pk, "version", SQE_VERSION);
 
 	key = "connection";
 	l = strlen(key);

--- a/sqe.h
+++ b/sqe.h
@@ -45,6 +45,8 @@
 
 #include "bsdqueue.h"
 
+#define SQE_VERSION "1.1.0"
+
 #define RT_UNKNOWN   0
 #define RT_SETOPT    1
 #define RT_GETOPT    2

--- a/t/queries.t
+++ b/t/queries.t
@@ -105,6 +105,7 @@ my %CLIENT_STATS = map { $_ => $NUMBER } @CLIENT_STATS;
 my %GLOBAL_STATS = map { $_ => $NUMBER } @GLOBAL_STATS;
 $CLIENT_STATS{oids_non_increasing} = 0;
 $GLOBAL_STATS{oids_non_increasing} = 0;
+$GLOBAL_STATS{version} = qr/^\d+\.\d+\.\d+$/;
 
 my $version_output = `$FindBin::Bin/../snmp-query-engine -v`;
 like($version_output, qr/^snmp-query-engine \d+\.\d+\.\d+$/, "-v prints semantic version");
@@ -322,6 +323,7 @@ $r = request_match("stats", [RT_INFO,5000], [RT_INFO|RT_REPLY,5000,
 	{ connection => \%CLIENT_STATS,
 	  global => \%GLOBAL_STATS}]);
 #print STDERR "OIDS requested: $r->[2]{connection}{oids_requested}\n";
+ok(!exists $r->[2]{connection}{version}, "version is a global-only stat");
 
 request_match("destinfo non-zero", [RT_DEST_INFO,6630,"127.0.0.1",161], [RT_DEST_INFO|RT_REPLY, 6630,
 			  { octets_received => $NON_ZERO, octets_sent => $NON_ZERO}]);

--- a/t/queries.t
+++ b/t/queries.t
@@ -106,6 +106,9 @@ my %GLOBAL_STATS = map { $_ => $NUMBER } @GLOBAL_STATS;
 $CLIENT_STATS{oids_non_increasing} = 0;
 $GLOBAL_STATS{oids_non_increasing} = 0;
 
+my $version_output = `$FindBin::Bin/../snmp-query-engine -v`;
+like($version_output, qr/^snmp-query-engine \d+\.\d+\.\d+$/, "-v prints semantic version");
+
 my $daemon_pid;
 if (!($daemon_pid = fork)) {
 	exec("$FindBin::Bin/../snmp-query-engine", "-p7668", "-q");


### PR DESCRIPTION
Converts snmp-query-engine to changie-managed changelogs and semantic
versioning.

## What changed

- **`SQE_VERSION` is the single version source of truth** (`sqe.h`),
  initialized to `1.1.0` (the latest backfilled release). Changie
  replacements rewrite it and the manual's VERSION line at release time.
- **`-v` CLI flag** prints `snmp-query-engine <version>` and exits. Output
  uses a fixed program name so it is stable across platforms (avoids
  `thisprogname()` returning a full path on Linux/Solaris).
- **`version` string stat** added to the INFO reply's global stats map
  (bare semver). The legacy integer `program_version` stays frozen at
  2023082200 for wire-protocol compatibility; it is unchanged.
- **Changie configuration** (`.changie.yaml`, header template, unreleased
  fragments) plus a **backfilled `CHANGELOG.md`** covering v0.1.0 through
  v1.1.0, generated by `changie merge`.

## Release note

The first tagged release must use `changie batch major` (→ v2.0.0)
explicitly — the fragments' kinds only auto-bump minor, so `batch auto`
would produce v1.2.0 by mistake. v2.0.0 signals the semver adoption; it is
not a wire-compatibility break (`program_version` still ships).

## Test plan

- [x] `make` builds clean
- [x] `./snmp-query-engine -v` prints `snmp-query-engine 1.1.0`
- [x] `prove t/queries.t`: 3 new subtests pass; the ~15 pre-existing
      environmental failures are unchanged by name (no new failures)
- [x] INFO reply carries `version` in the global map only, not per-connection
- [x] `changie latest` = v1.1.0; `CHANGELOG.md` has 13 versions, newest-first
- [x] `changie batch major --dry-run` → v2.0.0 with the four fragments;
      replacements idempotent at 1.1.0 (sqe.h/manual.mdwn unchanged)
