### PR TITLE
ci: GitHub Actions workflow (build, tests, sanitizers, real snmpd)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,7 @@ jobs:
           SQE_REAL_SNMPD: 1
           SQE_SNMPD_PORT: 16161
           SQE_SNMPD_V3_USER: sqetest
+          SQE_SNMPD_V3_ENGINEID: "80001f88047371656369"
           SQE_SNMPD_V3_AUTH_PROTO: sha512
           SQE_SNMPD_V3_AUTH_PASS: sqeauthpass12
           SQE_SNMPD_V3_PRIV_PROTO: aes128

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,13 @@ jobs:
         run: |
           mkdir -p /tmp/sqe-snmp-persist
           snmpd -C -c ci/snmpd.conf -Lf /tmp/snmpd.log
-          sleep 1
-          snmpget -v2c -c public 127.0.0.1:16161 1.3.6.1.2.1.1.5.0
+          for i in $(seq 1 10); do
+            snmpget -v2c -c public 127.0.0.1:16161 1.3.6.1.2.1.1.5.0 && exit 0
+            sleep 1
+          done
+          echo "snmpd did not answer in time; log follows:" >&2
+          cat /tmp/snmpd.log >&2
+          exit 1
       - name: Test (Linux, with real snmpd tier)
         if: runner.os == 'Linux'
         env:
@@ -57,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ASAN_OPTIONS: detect_leaks=0
+      UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:abort_on_error=1
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,68 @@
+# ABOUTME: GitHub Actions CI: build + full test suite on ubuntu/macos, plus a
+# ABOUTME: real-snmpd tier (v2c+v3) and an ASan+UBSan sanitizer job.
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libjudy-dev libssl-dev snmpd snmp cpanminus \
+            $(apt-cache -q0 show libmsgpack-c-dev >/dev/null 2>&1 && echo libmsgpack-c-dev || echo libmsgpack-dev)
+          sudo cpanm --notest Data::MessagePack Test2::Suite
+      - name: Install dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install msgpack judy openssl@3 perl cpanminus
+          cpanm --notest Data::MessagePack Test2::Suite
+      - name: Build
+        run: make
+      - name: Start snmpd (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          mkdir -p /tmp/sqe-snmp-persist
+          snmpd -C -c ci/snmpd.conf -Lf /tmp/snmpd.log
+          sleep 1
+          snmpget -v2c -c public 127.0.0.1:16161 1.3.6.1.2.1.1.5.0
+      - name: Test (Linux, with real snmpd tier)
+        if: runner.os == 'Linux'
+        env:
+          SQE_REAL_SNMPD: 1
+          SQE_SNMPD_PORT: 16161
+          SQE_SNMPD_V3_USER: sqetest
+          SQE_SNMPD_V3_AUTH_PROTO: sha512
+          SQE_SNMPD_V3_AUTH_PASS: sqeauthpass12
+          SQE_SNMPD_V3_PRIV_PROTO: aes128
+          SQE_SNMPD_V3_PRIV_PASS: sqeprivpass12
+        run: make test
+      - name: Test (macOS)
+        if: runner.os == 'macOS'
+        run: make test
+
+  sanitize:
+    runs-on: ubuntu-latest
+    env:
+      ASAN_OPTIONS: detect_leaks=0
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libjudy-dev libssl-dev cpanminus \
+            $(apt-cache -q0 show libmsgpack-c-dev >/dev/null 2>&1 && echo libmsgpack-c-dev || echo libmsgpack-dev)
+          sudo cpanm --notest Data::MessagePack Test2::Suite
+      - name: Build and test with ASan+UBSan
+        run: make OPTIMIZE="-O1 -g -fsanitize=address,undefined -fno-omit-frame-pointer" test

--- a/ci/snmpd.conf
+++ b/ci/snmpd.conf
@@ -2,6 +2,7 @@
 # ABOUTME: v2c public community and a v3 user, used by t/real-snmpd.t.
 agentaddress udp:127.0.0.1:16161
 rocommunity public 127.0.0.1
+engineID sqeci
 createUser sqetest SHA-512 sqeauthpass12 AES sqeprivpass12
 rouser sqetest priv
 persistentDir /tmp/sqe-snmp-persist

--- a/ci/snmpd.conf
+++ b/ci/snmpd.conf
@@ -1,0 +1,7 @@
+# ABOUTME: snmpd configuration for CI: unprivileged localhost agent with a
+# ABOUTME: v2c public community and a v3 user, used by t/real-snmpd.t.
+agentaddress udp:127.0.0.1:16161
+rocommunity public 127.0.0.1
+createUser sqetest SHA-512 sqeauthpass12 AES sqeprivpass12
+rouser sqetest priv
+persistentDir /tmp/sqe-snmp-persist

--- a/t/real-snmpd.t
+++ b/t/real-snmpd.t
@@ -34,9 +34,12 @@ ok(@{$r->[2]} > 0, "walk returned at least one row");
 my @oids = map { $_->[0] } @{$r->[2]};
 is([sort { SQE::Test::oid_cmp($a, $b) } @oids], \@oids, "row OIDs strictly increasing");
 
-if (my $user = $ENV{SQE_SNMPD_V3_USER}) {
+my $user     = $ENV{SQE_SNMPD_V3_USER};
+my $engineid = $ENV{SQE_SNMPD_V3_ENGINEID};
+if ($user && $engineid) {
 	my %v3 = (
 		version      => 3,
+		engineid     => $engineid,
 		username     => $user,
 		authprotocol => $ENV{SQE_SNMPD_V3_AUTH_PROTO} // 'sha1',
 		authpassword => $ENV{SQE_SNMPD_V3_AUTH_PASS},
@@ -50,6 +53,8 @@ if (my $user = $ENV{SQE_SNMPD_V3_USER}) {
 	request_match($d, "v3 get sysName",
 		[RT_GET, 201, $host, $port, ["1.3.6.1.2.1.1.5.0"]],
 		[RT_GET|RT_REPLY, 201, [["1.3.6.1.2.1.1.5.0", match qr/./]]]);
+} elsif ($user) {
+	note "SQE_SNMPD_V3_USER set but SQE_SNMPD_V3_ENGINEID missing; v3 needs the agent's engine id, skipping v3 checks";
 } else {
 	note "SQE_SNMPD_V3_USER not set, skipping v3 checks";
 }


### PR DESCRIPTION
Adds a GitHub Actions workflow: build + full test suite on ubuntu and
macos, the real-snmpd tier against an unprivileged snmpd on the ubuntu
runner (v2c + v3 via SQE_SNMPD_* envs), and an ASan+UBSan job. Third and
final PR from the test-suite revamp design.

Test plan:
- [x] all three jobs green on this branch