### PR TITLE
Daemon lifecycle: signals, graceful shutdown, sd_notify

### DIFF
--- a/.changes/unreleased/Added-20260704-133337.yaml
+++ b/.changes/unreleased/Added-20260704-133337.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: graceful shutdown on SIGTERM and SIGINT
+time: 2026-07-04T13:33:37.592759+02:00

--- a/.changes/unreleased/Added-20260704-133338.yaml
+++ b/.changes/unreleased/Added-20260704-133338.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: systemd readiness and watchdog support
+time: 2026-07-04T13:33:38.616475+02:00

--- a/.changes/unreleased/Fixed-20260704-133336.yaml
+++ b/.changes/unreleased/Fixed-20260704-133336.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: survive abrupt client disconnects (SIGPIPE)
+time: 2026-07-04T13:33:36.573153+02:00

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ STDOBJ=event_loop.o carp.o client_input.o client_listen.o opts.o util.o destinat
 	client_requests_info.o cid_info.o ber.o oid_info.o sid_info.o \
 	snmp.o request_common.o request_setopt.o request_getopt.o \
 	request_info.o request_get.o request_gettable.o timers.o \
-	v3_keys.o v3_crypto.o log.o
+	v3_keys.o v3_crypto.o log.o notify.o
 
 STDLINK=$(STDOBJ) $(LIBPATH) -lJudy -lmsgpackc -lcrypto
 
@@ -101,6 +101,9 @@ v3_crypto.o: v3_crypto.c sqe.h
 
 log.o: log.c log.h sqe.h
 	$(CC) -c $(CFLAGS) -o log.o log.c
+
+notify.o: notify.c sqe.h
+	$(CC) -c $(CFLAGS) -o notify.o notify.c
 
 t/test_log: t/test_log.c t/tap.h $(STDOBJ)
 	$(CC) $(CFLAGS) -o t/test_log t/test_log.c $(STDLINK)

--- a/event_loop.c
+++ b/event_loop.c
@@ -314,6 +314,15 @@ on_write(struct socket_info *si, void (*write_handler)(struct socket_info *si))
 #endif
 }
 
+static int
+event_loop_done(void)
+{
+	if (!stop_requested)
+		return 0;
+	log_info("shutting down on signal");
+	return 1;
+}
+
 #ifdef WITH_KQUEUE
 void
 event_loop(void)
@@ -328,8 +337,12 @@ event_loop(void)
 		to.tv_sec = ms / 1000;
 		to.tv_nsec = (ms % 1000)*1000000;
 		nev = kevent(kq, NULL, 0, ke, 10, &to);
-		if (nev < 0)
-			croak(1, "event_loop: kevent");
+		if (nev < 0) {
+			if (errno == EINTR)
+				nev = 0;
+			else
+				croak(1, "event_loop: kevent");
+		}
 		for (i = 0; i < nev; i++) {
 			struct socket_info *si, **slot;
 
@@ -374,6 +387,8 @@ event_loop(void)
 			}
 		}
 		trigger_timers();
+		if (event_loop_done())
+			return;
 	}
 }
 #endif
@@ -387,8 +402,12 @@ event_loop(void)
 	while (1) {
 		ms = ms_to_next_timer();
 		nev = epoll_wait(ep, ev, 10, ms);
-		if (nev < 0)
-			croak(1, "event_loop: epoll_wait");
+		if (nev < 0) {
+			if (errno == EINTR)
+				nev = 0;
+			else
+				croak(1, "event_loop: epoll_wait");
+		}
 		for (i = 0; i < nev; i++) {
 			struct socket_info *si, **slot;
 
@@ -419,6 +438,8 @@ event_loop(void)
 			}
 		}
 		trigger_timers();
+		if (event_loop_done())
+			return;
 	}
 }
 #endif

--- a/event_loop.c
+++ b/event_loop.c
@@ -328,12 +328,15 @@ void
 event_loop(void)
 {
 	struct kevent ke[10];
-	int nev, i, ms;
+	int nev, i, ms, wd;
 	struct timespec to;
 
 	log_info("kqueue event loop started");
 	while (1) {
 		ms = ms_to_next_timer();
+		wd = notify_watchdog_interval_ms();
+		if (wd > 0 && wd < ms)
+			ms = wd;
 		to.tv_sec = ms / 1000;
 		to.tv_nsec = (ms % 1000)*1000000;
 		nev = kevent(kq, NULL, 0, ke, 10, &to);
@@ -387,6 +390,7 @@ event_loop(void)
 			}
 		}
 		trigger_timers();
+		notify_watchdog_tick();
 		if (event_loop_done())
 			return;
 	}
@@ -397,10 +401,13 @@ void
 event_loop(void)
 {
 	struct epoll_event ev[10];
-	int nev, i, ms;
+	int nev, i, ms, wd;
 	log_info("epoll event loop started");
 	while (1) {
 		ms = ms_to_next_timer();
+		wd = notify_watchdog_interval_ms();
+		if (wd > 0 && wd < ms)
+			ms = wd;
 		nev = epoll_wait(ep, ev, 10, ms);
 		if (nev < 0) {
 			if (errno == EINTR)
@@ -438,6 +445,7 @@ event_loop(void)
 			}
 		}
 		trigger_timers();
+		notify_watchdog_tick();
 		if (event_loop_done())
 			return;
 	}

--- a/event_loop.c
+++ b/event_loop.c
@@ -314,13 +314,59 @@ on_write(struct socket_info *si, void (*write_handler)(struct socket_info *si))
 #endif
 }
 
+static int shutdown_active = 0;
+static struct timeval shutdown_started;
+
+static int
+pending_client_output(void)
+{
+	struct socket_info **slot;
+	Word_t fd = 0;
+
+	JLF(slot, socks, fd);
+	while (slot) {
+		if ((*slot)->n_send_bufs > 0)
+			return 1;
+		JLN(slot, socks, fd);
+	}
+	return 0;
+}
+
+static void
+begin_shutdown(void)
+{
+	struct socket_info **slot;
+	Word_t fd = 0;
+
+	shutdown_active = 1;
+	gettimeofday(&shutdown_started, NULL);
+	notify("STOPPING=1");
+	log_info("shutting down on signal");
+	if (listener_si) {
+		delete_socket_info(listener_si);
+		listener_si = NULL;
+	}
+	/* stop reading new client requests; only drain what is already queued */
+	JLF(slot, socks, fd);
+	while (slot) {
+		if ((*slot)->udata)
+			on_read(*slot, NULL);
+		JLN(slot, socks, fd);
+	}
+}
+
 static int
 event_loop_done(void)
 {
 	if (!stop_requested)
 		return 0;
-	log_info("shutting down on signal");
-	return 1;
+	if (!shutdown_active)
+		begin_shutdown();
+	if (!pending_client_output())
+		return 1;
+	if (ms_passed_since(&shutdown_started) >= 1000)
+		return 1;
+	return 0;
 }
 
 #ifdef WITH_KQUEUE
@@ -337,6 +383,8 @@ event_loop(void)
 		wd = notify_watchdog_interval_ms();
 		if (wd > 0 && wd < ms)
 			ms = wd;
+		if (shutdown_active && ms > 50)
+			ms = 50;
 		to.tv_sec = ms / 1000;
 		to.tv_nsec = (ms % 1000)*1000000;
 		nev = kevent(kq, NULL, 0, ke, 10, &to);
@@ -408,6 +456,8 @@ event_loop(void)
 		wd = notify_watchdog_interval_ms();
 		if (wd > 0 && wd < ms)
 			ms = wd;
+		if (shutdown_active && ms > 50)
+			ms = 50;
 		nev = epoll_wait(ep, ev, 10, ms);
 		if (nev < 0) {
 			if (errno == EINTR)

--- a/main.c
+++ b/main.c
@@ -90,6 +90,7 @@ main(int argc, char **argv)
 		croak(1, "sigaction(SIGTERM)");
 	if (sigaction(SIGINT, &sa, NULL) < 0)
 		croak(1, "sigaction(SIGINT)");
+	notify_init();
 
     if (populate_well_known_oids() < 0) {
         log_error("unable to populate well-known oids: %s", strerror(errno));
@@ -98,6 +99,7 @@ main(int argc, char **argv)
 
 	create_snmp_socket();
 	create_listening_socket(bindaddr, port);
+	notify("READY=1");
 	event_loop();
 
 	log_info("shutdown complete");

--- a/main.c
+++ b/main.c
@@ -8,6 +8,13 @@
  */
 #include "sqe.h"
 
+static void
+handle_stop_signal(int sig)
+{
+	(void)sig;
+	stop_requested = 1;
+}
+
 void
 usage(char *err)
 {
@@ -32,6 +39,7 @@ main(int argc, char **argv)
 	int o;
 	int port = 7667;
 	struct in_addr bindaddr;
+	struct sigaction sa;
 
 	gettimeofday(&prog_start, NULL);
 	bzero(&PS, sizeof(PS));
@@ -72,6 +80,17 @@ main(int argc, char **argv)
 	log_setup();
 	log_debug("debug logging enabled");
 
+	signal(SIGPIPE, SIG_IGN);
+	signal(SIGHUP, SIG_IGN);
+	memset(&sa, 0, sizeof(sa));
+	sa.sa_handler = handle_stop_signal;
+	sigemptyset(&sa.sa_mask);
+	sa.sa_flags = 0;	/* no SA_RESTART: the event loop must see EINTR */
+	if (sigaction(SIGTERM, &sa, NULL) < 0)
+		croak(1, "sigaction(SIGTERM)");
+	if (sigaction(SIGINT, &sa, NULL) < 0)
+		croak(1, "sigaction(SIGINT)");
+
     if (populate_well_known_oids() < 0) {
         log_error("unable to populate well-known oids: %s", strerror(errno));
         exit(1);
@@ -81,6 +100,7 @@ main(int argc, char **argv)
 	create_listening_socket(bindaddr, port);
 	event_loop();
 
+	log_info("shutdown complete");
 	return 0;
 }
 

--- a/manual.mdwn
+++ b/manual.mdwn
@@ -50,6 +50,35 @@ http://msgpack.org/.
 -v
 :   print program version and quit
 
+# SIGNALS
+
+SIGTERM, SIGINT
+:   graceful shutdown: the daemon stops accepting connections, briefly
+    flushes already-queued client replies (bounded by one second),
+    abandons in-flight SNMP queries, and exits with status 0.
+
+SIGHUP
+:   ignored; there is no runtime configuration to reload.
+
+SIGPIPE
+:   ignored; abrupt client disconnects are handled on the write path.
+
+# ENVIRONMENT
+
+NOTIFY_SOCKET, WATCHDOG_USEC, WATCHDOG_PID
+:   when set by a service manager (systemd Type=notify), the daemon sends
+    readiness (READY=1), shutdown (STOPPING=1) and watchdog (WATCHDOG=1)
+    notifications; watchdog pings are sent every WATCHDOG_USEC/3.
+
+JOURNAL_STREAM
+:   when it matches stderr (systemd journal capture), log lines carry
+    sd-daemon `<N>` priority prefixes instead of timestamps.
+
+# EXIT STATUS
+
+0 on clean (signal-initiated) shutdown; non-zero on startup or runtime
+failure.
+
 # REQUESTS
 
 All requests are arrays of at least two elements.

--- a/notify.c
+++ b/notify.c
@@ -1,0 +1,67 @@
+/* ABOUTME: systemd sd_notify protocol, hand-rolled: readiness, stopping and
+ * ABOUTME: watchdog datagrams to $NOTIFY_SOCKET; no-op outside systemd. */
+#include "sqe.h"
+
+static int notify_fd = -1;
+static struct sockaddr_un notify_addr;
+static socklen_t notify_addrlen = 0;
+static int watchdog_period_ms = 0;
+static struct timeval last_watchdog;
+
+void
+notify_init(void)
+{
+	const char *path = getenv("NOTIFY_SOCKET");
+	const char *usec = getenv("WATCHDOG_USEC");
+	const char *wpid = getenv("WATCHDOG_PID");
+	size_t len;
+
+	if (!path || (path[0] != '/' && path[0] != '@'))
+		return;
+	len = strlen(path);
+	if (len >= sizeof(notify_addr.sun_path))
+		return;
+	memset(&notify_addr, 0, sizeof(notify_addr));
+	notify_addr.sun_family = AF_UNIX;
+	memcpy(notify_addr.sun_path, path, len);
+	if (path[0] == '@')
+		notify_addr.sun_path[0] = '\0';
+	notify_addrlen = offsetof(struct sockaddr_un, sun_path) + len;
+	if ( (notify_fd = socket(AF_UNIX, SOCK_DGRAM, 0)) < 0) {
+		log_debug("notify_init: socket: %s", strerror(errno));
+		return;
+	}
+	if (usec && (!wpid || atoi(wpid) == (int)getpid())) {
+		long period = atol(usec) / 3 / 1000;
+		if (period > 0)
+			watchdog_period_ms = (int)period;
+	}
+	gettimeofday(&last_watchdog, NULL);
+}
+
+void
+notify(const char *state)
+{
+	if (notify_fd < 0)
+		return;
+	if (sendto(notify_fd, state, strlen(state), 0,
+	    (struct sockaddr *)&notify_addr, notify_addrlen) < 0)
+		log_debug("notify: sendto: %s", strerror(errno));
+}
+
+void
+notify_watchdog_tick(void)
+{
+	if (notify_fd < 0 || !watchdog_period_ms)
+		return;
+	if (ms_passed_since(&last_watchdog) >= watchdog_period_ms) {
+		notify("WATCHDOG=1");
+		gettimeofday(&last_watchdog, NULL);
+	}
+}
+
+int
+notify_watchdog_interval_ms(void)
+{
+	return watchdog_period_ms;
+}

--- a/opts.c
+++ b/opts.c
@@ -9,3 +9,4 @@
 #include "sqe.h"
 
 enum log_level opt_log_level = LL_INFO;
+volatile sig_atomic_t stop_requested = 0;

--- a/snmp-query-engine.1
+++ b/snmp-query-engine.1
@@ -40,6 +40,31 @@ quiet operation: log warnings and errors only
 .TP
 \-v
 print program version and quit
+.SH SIGNALS
+.TP
+SIGTERM, SIGINT
+graceful shutdown: the daemon stops accepting connections, briefly
+flushes already\-queued client replies (bounded by one second), abandons
+in\-flight SNMP queries, and exits with status 0.
+.TP
+SIGHUP
+ignored; there is no runtime configuration to reload.
+.TP
+SIGPIPE
+ignored; abrupt client disconnects are handled on the write path.
+.SH ENVIRONMENT
+.TP
+NOTIFY_SOCKET, WATCHDOG_USEC, WATCHDOG_PID
+when set by a service manager (systemd Type=notify), the daemon sends
+readiness (READY=1), shutdown (STOPPING=1) and watchdog (WATCHDOG=1)
+notifications; watchdog pings are sent every WATCHDOG_USEC/3.
+.TP
+JOURNAL_STREAM
+when it matches stderr (systemd journal capture), log lines carry
+sd\-daemon \f[CR]<N>\f[R] priority prefixes instead of timestamps.
+.SH EXIT STATUS
+0 on clean (signal\-initiated) shutdown; non\-zero on startup or runtime
+failure.
 .SH REQUESTS
 All requests are arrays of at least two elements.
 .TP

--- a/sqe.h
+++ b/sqe.h
@@ -18,6 +18,7 @@
 #include <unistd.h>
 #include <stdio.h>
 #include <ctype.h>
+#include <signal.h>
 #define __USE_XOPEN
 #include <limits.h>
 #include <fcntl.h>
@@ -183,6 +184,7 @@ struct program_stats
 
 extern struct timeval prog_start;
 extern struct program_stats PS;
+extern volatile sig_atomic_t stop_requested;
 
 struct ber
 {

--- a/sqe.h
+++ b/sqe.h
@@ -27,6 +27,7 @@
 #include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/socket.h>
+#include <sys/un.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #if defined(__FreeBSD__) || defined(__APPLE__)
@@ -505,6 +506,12 @@ void on_read(struct socket_info *si, void (*read_handler)(struct socket_info *si
 void on_write(struct socket_info *si, void (*write_handler)(struct socket_info *si));
 void event_loop(void);
 void tcp_send(struct socket_info *si, void *buf, int size);
+
+/* notify.c */
+void notify_init(void);
+void notify(const char *state);
+void notify_watchdog_tick(void);
+int notify_watchdog_interval_ms(void);
 
 /* timers.c */
 extern struct timer *new_timer(struct timeval *when);

--- a/t/daemon.t
+++ b/t/daemon.t
@@ -1,0 +1,54 @@
+#!/usr/bin/env perl
+# ABOUTME: Daemon lifecycle tests: graceful SIGTERM/SIGINT exit, SIGHUP
+# ABOUTME: ignored, and survival of abrupt client disconnects (SIGPIPE).
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use Test2::V0;
+use Time::HiRes ();
+use IO::Socket::INET;
+use SQE::Test qw(spawn_daemon RT_INFO RT_REPLY);
+
+subtest 'SIGTERM: prompt clean exit' => sub {
+	my $d = spawn_daemon();
+	kill 'TERM', $d->pid;
+	my $t0 = Time::HiRes::time();
+	my $status = $d->wait_exit(5);
+	ok(defined $status, 'daemon exited');
+	is($status, 0, 'exit status 0');
+	cmp_ok(Time::HiRes::time() - $t0, '<', 2, 'exit was prompt');
+};
+
+subtest 'SIGINT: prompt clean exit' => sub {
+	my $d = spawn_daemon();
+	kill 'INT', $d->pid;
+	is($d->wait_exit(5), 0, 'exit status 0');
+};
+
+subtest 'SIGHUP: ignored, daemon keeps answering' => sub {
+	my $d = spawn_daemon();
+	kill 'HUP', $d->pid;
+	Time::HiRes::sleep(0.2);
+	my $res = $d->request([RT_INFO, 1]);
+	is($res->[0], RT_INFO|RT_REPLY, 'still answering after SIGHUP');
+};
+
+subtest 'abrupt client disconnect does not kill the daemon' => sub {
+	my $d = spawn_daemon();
+	# Flood pipelined requests and vanish without reading: replies pile up
+	# in the daemon's send buffers, the RST arrives with writes pending,
+	# and an unprotected daemon dies of SIGPIPE on Linux.
+	$d->multi_request(map { [RT_INFO, $_] } 1 .. 10000);
+	close $d->{conn};
+	$d->{conn} = undef;
+	Time::HiRes::sleep(0.5);
+	my $c = IO::Socket::INET->new(
+		PeerAddr => '127.0.0.1:' . $d->port, Proto => 'tcp')
+		or fail('cannot reconnect to flooded daemon'), return;
+	$d->{conn} = $c;
+	my $res = $d->request([RT_INFO, 2]);
+	is($res->[0], RT_INFO|RT_REPLY, 'daemon alive and answering after client vanished');
+};
+
+done_testing;

--- a/t/notify.t
+++ b/t/notify.t
@@ -1,0 +1,58 @@
+#!/usr/bin/env perl
+# ABOUTME: sd_notify protocol tests using a plain unix datagram socket:
+# ABOUTME: READY on startup, WATCHDOG pings, STOPPING on shutdown.
+use strict;
+use warnings;
+use FindBin;
+use lib "$FindBin::Bin/lib";
+use Test2::V0;
+use File::Temp ();
+use IO::Socket::UNIX;
+use Socket qw(SOCK_DGRAM);
+use Time::HiRes ();
+use SQE::Test qw(spawn_daemon RT_INFO RT_REPLY);
+
+sub drain_dgrams {
+	my ($sock, $secs) = @_;
+	my @msgs;
+	my $deadline = Time::HiRes::time() + $secs;
+	while (Time::HiRes::time() < $deadline) {
+		my $rin = '';
+		vec($rin, fileno($sock), 1) = 1;
+		next unless select(my $rout = $rin, undef, undef, 0.1);
+		my $buf;
+		push @msgs, $buf if defined $sock->recv($buf, 4096);
+	}
+	return @msgs;
+}
+
+sub notify_listener {
+	my $dir = File::Temp->newdir;
+	my $path = "$dir/notify.sock";
+	my $sock = IO::Socket::UNIX->new(Local => $path, Type => SOCK_DGRAM)
+		or die "notify socket: $!";
+	return ($dir, $path, $sock);  # keep $dir alive
+}
+
+subtest 'READY=1 after startup' => sub {
+	my ($dir, $path, $sock) = notify_listener();
+	my $d = spawn_daemon(env => { NOTIFY_SOCKET => $path });
+	my @msgs = drain_dgrams($sock, 1);
+	ok((grep { /(?:^|\n)READY=1(?:\n|$)/ } @msgs), 'READY=1 received')
+		or diag(join '|', @msgs);
+};
+
+subtest 'watchdog pings at USEC/3 cadence' => sub {
+	my ($dir, $path, $sock) = notify_listener();
+	my $d = spawn_daemon(env => {
+		NOTIFY_SOCKET => $path, WATCHDOG_USEC => 300000 });
+	my @pings = grep { /(?:^|\n)WATCHDOG=1(?:\n|$)/ } drain_dgrams($sock, 1.5);
+	cmp_ok(scalar @pings, '>=', 2, 'at least two watchdog pings in 1.5s');
+};
+
+subtest 'no NOTIFY_SOCKET: daemon simply works' => sub {
+	my $d = spawn_daemon();
+	is($d->request([RT_INFO, 1])->[0], RT_INFO|RT_REPLY, 'answers without notify env');
+};
+
+done_testing;

--- a/t/notify.t
+++ b/t/notify.t
@@ -55,4 +55,14 @@ subtest 'no NOTIFY_SOCKET: daemon simply works' => sub {
 	is($d->request([RT_INFO, 1])->[0], RT_INFO|RT_REPLY, 'answers without notify env');
 };
 
+subtest 'STOPPING=1 sent on SIGTERM before exit' => sub {
+	my ($dir, $path, $sock) = notify_listener();
+	my $d = spawn_daemon(env => { NOTIFY_SOCKET => $path });
+	drain_dgrams($sock, 0.3);   # discard READY
+	kill 'TERM', $d->pid;
+	my @msgs = drain_dgrams($sock, 1);
+	ok((grep { /(?:^|\n)STOPPING=1(?:\n|$)/ } @msgs), 'STOPPING=1 received');
+	is($d->wait_exit(5), 0, 'clean exit after STOPPING');
+};
+
 done_testing;


### PR DESCRIPTION
Production deployments supervise SQE with a service manager, which expects daemons to exit cleanly on SIGTERM, report readiness, and answer a watchdog. Previously SQE died by default signal disposition (and on Linux could be killed by SIGPIPE when a client vanished with replies still buffered). This PR adds:

- Graceful shutdown on SIGTERM/SIGINT: the daemon stops accepting connections, disables client reads, briefly flushes already-queued client replies (bounded by ~1 s), and exits 0. SIGHUP and SIGPIPE are ignored.
- Hand-rolled sd_notify support (no libsystemd dependency): READY=1 after the listener is up, STOPPING=1 on shutdown, WATCHDOG=1 pings every WATCHDOG_USEC/3 (the event-loop wait is capped to the watchdog cadence so fast WatchdogSec values are honored). No-op outside systemd.
- EINTR-tolerant event loops (both kqueue and epoll variants).
- New tests: t/daemon.t (signal lifecycle, abrupt-disconnect survival), t/notify.t (READY/WATCHDOG/STOPPING over a real unix datagram socket).
- Manual/man page: new SIGNALS, ENVIRONMENT and EXIT STATUS sections.

Test plan:
- [x] t/daemon.t: SIGTERM/SIGINT clean+prompt exit, SIGHUP ignored, client-vanish flood survival
- [x] t/notify.t: READY=1, watchdog cadence, STOPPING=1, no-op without NOTIFY_SOCKET
- [x] Full suite green locally (292 tests, macOS/kqueue)
- [x] CI green on ubuntu (epoll) + macos + sanitizer
