### PR TITLE
Install target, service files, deployment docs

### DIFF
--- a/.changes/unreleased/Added-20260704-140659.yaml
+++ b/.changes/unreleased/Added-20260704-140659.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: make install target
+time: 2026-07-04T14:06:59.912363+02:00

--- a/.changes/unreleased/Added-20260704-140700.yaml
+++ b/.changes/unreleased/Added-20260704-140700.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: example systemd unit and FreeBSD rc.d script
+time: 2026-07-04T14:07:00.934092+02:00

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Verify shipped service files (Linux)
         if: runner.os == 'Linux'
         run: |
-          sudo cp snmp-query-engine /usr/local/bin/
+          sudo make install
           systemd-analyze verify contrib/systemd/snmp-query-engine.service
           sh -n contrib/rc.d/snmp_query_engine
       - name: Verify shipped service files (macOS)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,15 @@ jobs:
           cpanm --notest Data::MessagePack Test2::Suite
       - name: Build
         run: make
+      - name: Verify shipped service files (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo cp snmp-query-engine /usr/local/bin/
+          systemd-analyze verify contrib/systemd/snmp-query-engine.service
+          sh -n contrib/rc.d/snmp_query_engine
+      - name: Verify shipped service files (macOS)
+        if: runner.os == 'macOS'
+        run: sh -n contrib/rc.d/snmp_query_engine
       - name: Start snmpd (Linux)
         if: runner.os == 'Linux'
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,217 @@
+# Installing snmp-query-engine
+
+This document covers building `snmp-query-engine` from source, installing it
+with `make install`, and running it under a service supervisor. It assumes
+familiarity with basic Unix system administration.
+
+## 1. Building from source
+
+`snmp-query-engine` needs a C compiler, `libmsgpack`, `libJudy`, and
+`libcrypto` (from OpenSSL). Perl and two CPAN modules are needed to run the
+test suite, but not to build or run the daemon itself.
+
+On Ubuntu/Debian:
+
+```sh
+apt-get install libmsgpack-dev libjudy-dev libssl-dev
+```
+
+Some newer Debian/Ubuntu releases renamed the msgpack package to
+`libmsgpack-c-dev`; use whichever your release provides.
+
+On FreeBSD:
+
+```sh
+pkg install msgpack judy openssl
+```
+
+On macOS (Homebrew):
+
+```sh
+brew install msgpack judy openssl@3
+```
+
+Then build:
+
+```sh
+make
+```
+
+and run the test suite:
+
+```sh
+make test
+```
+
+The test suite runs the C unit tests directly and the Perl integration tests
+via `prove`. The Perl tests need `Data::MessagePack` and `Test2::Suite` from
+CPAN:
+
+```sh
+cpan Data::MessagePack Test2::Suite
+```
+
+No local `snmpd` is required for `make test`; a scriptable fake SNMP agent
+stands in for one. See `README.markdown` for how to additionally run the
+suite against a real SNMP agent.
+
+## 2. Installing
+
+```sh
+make install
+```
+
+installs the binary to `$PREFIX/bin/snmp-query-engine` and the man page to
+`$PREFIX/share/man/man1/snmp-query-engine.1`. `PREFIX` defaults to
+`/usr/local`. Override it, or the more specific `BINDIR`/`MANDIR`, as needed:
+
+```sh
+make install PREFIX=/opt/snmp-query-engine
+```
+
+Packagers can stage the install under a temporary root with `DESTDIR`, which
+is prepended to `BINDIR`/`MANDIR` without affecting the paths baked into the
+binary:
+
+```sh
+make install DESTDIR=/tmp/stage PREFIX=/usr
+```
+
+`contrib/systemd/snmp-query-engine.service` and `contrib/rc.d/snmp_query_engine`
+are not installed by `make install`; copy them into place as shown below.
+
+## 3. Running under systemd
+
+Copy the example unit into a path systemd searches for vendor-supplied units
+(systemd 240 and later look here by default):
+
+```sh
+cp contrib/systemd/snmp-query-engine.service /usr/local/lib/systemd/system/
+systemctl daemon-reload
+systemctl enable --now snmp-query-engine
+```
+
+The unit runs `snmp-query-engine` directly (no forking) and expects the
+binary at `/usr/local/bin/snmp-query-engine` — the default `make install`
+location. If you installed to a different `PREFIX`, adjust `ExecStart` in a
+drop-in rather than editing the shipped file in place.
+
+Command-line flags are supplied via `/etc/default/snmp-query-engine`, which
+the unit reads through `EnvironmentFile=-/etc/default/snmp-query-engine` (the
+leading `-` means the file is optional). Set `SQE_OPTS` to whatever flags you
+want passed on `ExecStart`:
+
+```sh
+SQE_OPTS=-q
+```
+
+Logs go to the systemd journal (stdout/stderr are captured automatically);
+view them with:
+
+```sh
+journalctl -u snmp-query-engine
+```
+
+Reading the journal as a non-root user may require membership in the
+`systemd-journal` group (or `adm` on some distributions).
+
+The unit is `Type=notify` with `WatchdogSec=30`: the daemon signals readiness
+to systemd only once its sockets are open, so `systemctl start` doesn't
+return "active" until the daemon can actually accept connections, and
+`Restart=always` combined with the watchdog ping restarts the daemon if it
+stops responding. `DynamicUser=yes` runs the daemon under a transient,
+unprivileged, per-invocation user, since the daemon writes no files and needs
+no persistent identity. If you need a stable, fixed user instead (for
+example to match firewall rules keyed on UID), override it in a drop-in:
+
+```sh
+systemctl edit snmp-query-engine
+```
+
+```ini
+[Service]
+DynamicUser=no
+User=snmp-query-engine
+Group=snmp-query-engine
+```
+
+## 4. Running under FreeBSD rc.d
+
+Copy the example script into the local rc.d directory and mark it
+executable:
+
+```sh
+cp contrib/rc.d/snmp_query_engine /usr/local/etc/rc.d/
+chmod +x /usr/local/etc/rc.d/snmp_query_engine
+```
+
+Enable the service and configure it via `rc.conf` (`sysrc` edits `rc.conf`
+for you):
+
+```sh
+sysrc snmp_query_engine_enable=YES
+sysrc snmp_query_engine_args="-q"
+```
+
+Note the variable name: `snmp_query_engine_args`, not
+`snmp_query_engine_flags`. The script wraps `snmp-query-engine` in
+`daemon(8)`, and `rc.subr` reserves `_flags` for arguments to the wrapped
+`command` — which here is `daemon(8)` itself, not `snmp-query-engine`.
+`snmp_query_engine_args` is the script's own variable for the daemon's own
+flags.
+
+By default the script runs the daemon as user `nobody`
+(`snmp_query_engine_user`). A dedicated unprivileged user is recommended over
+the default:
+
+```sh
+pw useradd snmp-query-engine -c "snmp-query-engine daemon" -d /nonexistent -s /usr/sbin/nologin
+sysrc snmp_query_engine_user=snmp-query-engine
+```
+
+`daemon(8)` supervises the process (restarting it if it exits), writes a
+pidfile, and redirects its stderr to syslog under the `daemon` facility with
+tag `snmp-query-engine`, so no `newsyslog` configuration is required beyond
+whatever your system already does for the `daemon` facility.
+
+Start it:
+
+```sh
+service snmp_query_engine start
+```
+
+## 5. Running under any other supervisor
+
+`snmp-query-engine` is a plain foreground process that logs to stderr and
+exits cleanly on `SIGTERM` or `SIGINT`, so it fits any process supervisor
+without special support. For example, under runit:
+
+```sh
+#!/bin/sh
+exec snmp-query-engine -q 2>&1
+```
+
+or under supervisord:
+
+```ini
+[program:snmp-query-engine]
+command=/usr/local/bin/snmp-query-engine -q
+autorestart=true
+stopsignal=TERM
+```
+
+## 6. Upgrading
+
+Build or download the new binary, replace the installed one, and restart the
+service (`systemctl restart snmp-query-engine`, `service snmp_query_engine
+restart`, or your supervisor's equivalent). There is no on-disk state or
+schema to migrate.
+
+To confirm which version is running, either ask the binary directly:
+
+```sh
+snmp-query-engine -v
+```
+
+or query a running daemon over its client protocol: an `info` request's
+reply includes a `version` field alongside its usual statistics.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ LIBPATH=	-L/usr/local/lib -L/opt/local/lib -L/opt/homebrew/lib
 CFLAGS=	-Wall -Wno-unused-function -Wno-deprecated-declarations -Werror $(OPTIMIZE) $(INCPATH)
 TESTBIN=	t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log
 
+PREFIX?=	/usr/local
+BINDIR?=	$(PREFIX)/bin
+MANDIR?=	$(PREFIX)/share/man
+
 all: snmp-query-engine $(TESTBIN)
 
 STDOBJ=event_loop.o carp.o client_input.o client_listen.o opts.o util.o destination.o \
@@ -26,6 +30,12 @@ STDLINK=$(STDOBJ) $(LIBPATH) -lJudy -lmsgpackc -lcrypto
 clean:
 	rm -f *.o snmp-query-engine t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log *.core core
 	rm -rf t/*.dSYM *.dSYM
+
+install: snmp-query-engine
+	mkdir -p $(DESTDIR)$(BINDIR)
+	mkdir -p $(DESTDIR)$(MANDIR)/man1
+	install -m 755 snmp-query-engine $(DESTDIR)$(BINDIR)
+	install -m 644 snmp-query-engine.1 $(DESTDIR)$(MANDIR)/man1
 
 snmp-query-engine: main.o $(STDOBJ)
 	$(CC) $(CFLAGS) -o snmp-query-engine main.o $(STDLINK)

--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,11 @@ induced by multiple SNMP queries.
 
 See `manual.mdwn` for more.
 
+## Installation
+
+See `INSTALL.md` for building, `make install`, and running under
+systemd (Linux) or rc.d (FreeBSD).
+
 With regard to msgpack dependency:  snmp-query-engine
 requires at least msgpack 0.5.7, previous versions
 have bugs.  Unfortunately, msgpack website has changed

--- a/contrib/rc.d/snmp_query_engine
+++ b/contrib/rc.d/snmp_query_engine
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# PROVIDE: snmp_query_engine
+# REQUIRE: NETWORKING
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name=snmp_query_engine
+rcvar=snmp_query_engine_enable
+
+load_rc_config $name
+
+: ${snmp_query_engine_enable:="NO"}
+: ${snmp_query_engine_user:="nobody"}
+: ${snmp_query_engine_args:=""}
+
+pidfile="/var/run/${name}.pid"
+procname="/usr/local/bin/snmp-query-engine"
+command="/usr/sbin/daemon"
+command_args="-rS -T snmp-query-engine -P ${pidfile} \
+    -u ${snmp_query_engine_user} ${procname} ${snmp_query_engine_args}"
+
+run_rc_command "$1"

--- a/contrib/systemd/snmp-query-engine.service
+++ b/contrib/systemd/snmp-query-engine.service
@@ -1,0 +1,37 @@
+[Unit]
+Description=Multiplexing SNMP query engine
+Documentation=man:snmp-query-engine(1) https://github.com/tobez/snmp-query-engine
+After=network.target
+
+[Service]
+Type=notify
+EnvironmentFile=-/etc/default/snmp-query-engine
+ExecStart=/usr/local/bin/snmp-query-engine $SQE_OPTS
+Restart=always
+RestartSec=1
+WatchdogSec=30
+
+# SQE keeps one UDP socket per polled destination plus client connections.
+LimitNOFILE=65536
+
+# SQE writes no files and needs no privileges: run it as a transient user.
+DynamicUser=yes
+
+# Hardening. SQE needs only network sockets (and AF_UNIX for sd_notify).
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectKernelModules=yes
+ProtectControlGroups=yes
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+MemoryDenyWriteExecute=yes
+SystemCallFilter=@system-service
+
+[Install]
+WantedBy=multi-user.target

--- a/t/install.t
+++ b/t/install.t
@@ -1,0 +1,17 @@
+#!/usr/bin/env perl
+# ABOUTME: Verifies make install places the binary and man page under
+# ABOUTME: DESTDIR with the default PREFIX layout.
+use strict;
+use warnings;
+use FindBin;
+use Test2::V0;
+use File::Temp ();
+
+my $root = "$FindBin::Bin/..";
+my $dir = File::Temp->newdir;
+my $out = qx(make -C $root install DESTDIR=$dir 2>&1);
+is($? >> 8, 0, 'make install succeeds') or diag($out);
+ok(-x "$dir/usr/local/bin/snmp-query-engine", 'binary installed executable');
+ok(-f "$dir/usr/local/share/man/man1/snmp-query-engine.1", 'man page installed');
+
+done_testing;


### PR DESCRIPTION
Gives production deployments a proper install and supervision story: a
portable `make install` target, example service files for systemd and
FreeBSD rc.d, and a deployment guide.

- `make install` honors `PREFIX` (default `/usr/local`), `BINDIR`, `MANDIR`
  and `DESTDIR`, installing the binary and the man page.
- `contrib/systemd/snmp-query-engine.service`: `Type=notify` unit with
  watchdog, `DynamicUser` and hardening, using the readiness/watchdog
  support from #17.
- `contrib/rc.d/snmp_query_engine`: FreeBSD rc.d script running the daemon
  under daemon(8) with syslog logging.
- CI now verifies the shipped service files (`systemd-analyze verify` on
  Linux, `sh -n` shell syntax check on both platforms).
- `INSTALL.md` covers building from source, installing, and running under
  systemd, rc.d, or any other supervisor; README points to it.

Test plan:

- [x] `t/install.t`: `make install` under `DESTDIR` places binary and man page (default layout)
- [x] full suite green locally on macOS/kqueue (295 tests, 14 files)
- [x] CI: ubuntu (epoll) + macos + sanitize legs, including the new service-file verification steps

