### PR TITLE
Tagged-release artifacts: source tarball and static Linux binaries

### DIFF
--- a/.changes/unreleased/Added-20260704-145700.yaml
+++ b/.changes/unreleased/Added-20260704-145700.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: tagged releases ship prebuilt Linux binaries and a source tarball
+time: 2026-07-04T14:57:00.668564+02:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ name: release
 on:
   push:
     tags: ['v*']
+    branches: ['release-artifacts']
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,92 @@
+# ABOUTME: Release workflow: on v* tag push, builds a source tarball and
+# ABOUTME: static-deps Linux binaries, then creates the GitHub release.
+name: release
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  STATIC_LIBS: >-
+    -Wl,-Bstatic -lJudy -lmsgpackc -lcrypto -Wl,-Bdynamic -ldl -pthread
+
+jobs:
+  tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Create source tarball
+        run: |
+          VER=${GITHUB_REF_NAME#v}
+          git archive --format=tar.gz --prefix="snmp-query-engine-${VER}/" \
+            -o "snmp-query-engine-${VER}.tar.gz" HEAD
+      - uses: actions/upload-artifact@v7
+        with:
+          name: tarball
+          path: snmp-query-engine-*.tar.gz
+
+  linux-binary:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            arch: x86_64
+          - runner: ubuntu-22.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libjudy-dev libssl-dev cpanminus \
+            $(apt-cache -q0 show libmsgpack-c-dev >/dev/null 2>&1 && echo libmsgpack-c-dev || echo libmsgpack-dev)
+          sudo cpanm --notest Data::MessagePack Test2::Suite
+      - name: Build with static dependencies
+        run: make LIBS="$STATIC_LIBS"
+      - name: Verify static linking
+        run: |
+          ldd snmp-query-engine
+          ! ldd snmp-query-engine | grep -E 'msgpack|Judy|crypto'
+          ./snmp-query-engine -v
+      - name: Test
+        run: make LIBS="$STATIC_LIBS" test
+      - name: Name artifact
+        run: |
+          VER=${GITHUB_REF_NAME#v}
+          cp snmp-query-engine "snmp-query-engine-${VER}-linux-${{ matrix.arch }}"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: linux-${{ matrix.arch }}
+          path: snmp-query-engine-*-linux-*
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/')
+    needs: [tarball, linux-binary]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          path: dist
+          merge-multiple: true
+      - name: Extract changelog section
+        run: |
+          awk -v ver="$GITHUB_REF_NAME" '
+            $0 ~ "^## \\[" ver "\\]" {on=1; next}
+            on && /^## \[/ {exit}
+            on {print}' CHANGELOG.md > notes.md
+          test -s notes.md
+      - name: Checksums
+        run: cd dist && sha256sum * > SHA256SUMS
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" \
+            --notes-file notes.md dist/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ name: release
 on:
   push:
     tags: ['v*']
-    branches: ['release-artifacts']
   workflow_dispatch:
 
 permissions:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -57,6 +57,27 @@ suite against a real SNMP agent.
 
 ## 2. Installing
 
+### Prebuilt binaries
+
+Tagged releases publish prebuilt Linux binaries as GitHub release assets,
+alongside a source tarball. No compiler or dependencies are needed to use
+these.
+
+Each release ships `snmp-query-engine-X.Y.Z-linux-x86_64` and
+`snmp-query-engine-X.Y.Z-linux-arm64`, a `snmp-query-engine-X.Y.Z.tar.gz`
+source tarball, and a `SHA256SUMS` file covering all of them. The binaries
+statically link `msgpack`, `Judy`, and OpenSSL's `libcrypto`; glibc is linked
+dynamically, so the target system needs a glibc no older than Ubuntu 22.04's.
+
+Verify a downloaded binary against the published checksums before running
+it:
+
+```sh
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+### From a source build
+
 ```sh
 make install
 ```

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ TESTBIN=	t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log
 PREFIX?=	/usr/local
 BINDIR?=	$(PREFIX)/bin
 MANDIR?=	$(PREFIX)/share/man
+LIBS?=	-lJudy -lmsgpackc -lcrypto
 
 all: snmp-query-engine $(TESTBIN)
 
@@ -25,7 +26,7 @@ STDOBJ=event_loop.o carp.o client_input.o client_listen.o opts.o util.o destinat
 	request_info.o request_get.o request_gettable.o timers.o \
 	v3_keys.o v3_crypto.o log.o notify.o
 
-STDLINK=$(STDOBJ) $(LIBPATH) -lJudy -lmsgpackc -lcrypto
+STDLINK=$(STDOBJ) $(LIBPATH) $(LIBS)
 
 clean:
 	rm -f *.o snmp-query-engine t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log *.core core

--- a/README.markdown
+++ b/README.markdown
@@ -13,8 +13,8 @@ See `manual.mdwn` for more.
 
 ## Installation
 
-See `INSTALL.md` for building, `make install`, and running under
-systemd (Linux) or rc.d (FreeBSD).
+See `INSTALL.md` for building from source, prebuilt binaries, `make
+install`, and running under systemd (Linux) or rc.d (FreeBSD).
 
 With regard to msgpack dependency:  snmp-query-engine
 requires at least msgpack 0.5.7, previous versions


### PR DESCRIPTION
Adds a tag-triggered release workflow so production deployments can use
prebuilt binaries instead of building from source.

- Pushing a `v*` tag builds a source tarball and Linux binaries for
  x86_64 and arm64 (msgpack, Judy and OpenSSL statically linked; glibc
  dynamic, Ubuntu 22.04 floor), checksums them, and creates the GitHub
  release with the changelog section as notes.
- The build verifies static linking (`ldd` must show none of the three
  libraries) and runs the full test suite against the statically linked
  build.
- The Makefile's link libraries become an overridable `LIBS` variable
  (default unchanged) — the seam the static build uses.
- `INSTALL.md` gains a "Prebuilt binaries" section (artifact names, glibc
  requirement, `sha256sum -c` verification); README pointer updated.
- `workflow_dispatch` allows dry-running the build jobs without tagging;
  the release job itself only runs on tags.

Test plan:

- [x] full suite green locally (295 tests) and default build behavior unchanged with the `LIBS` refactor
- [x] dry-run of the workflow from this branch: tarball + both linux-binary legs green, static-link verification passed, release job skipped (run 28706163318)
- [x] CI: standard test workflow legs on this PR

