### PR TITLE
fix: declare croak/croakx noreturn for compiler and static analyzer

### DIFF
--- a/carp.c
+++ b/carp.c
@@ -8,14 +8,14 @@
  */
 #include "sqe.h"
 
-static void v(int is_croak, int is_x, int exit_code, const char *fmt, va_list ap);
+static void v(int use_errno, int exit_code, const char *fmt, va_list ap) __attribute__((noreturn));
 
 void
 croak(int exit_code, const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	v(1, errno, exit_code, fmt, ap);
+	v(errno, exit_code, fmt, ap);
 	va_end(ap);
 }
 
@@ -24,12 +24,12 @@ croakx(int exit_code, const char *fmt, ...)
 {
 	va_list ap;
 	va_start(ap, fmt);
-	v(1, -1, exit_code, fmt, ap);
+	v(-1, exit_code, fmt, ap);
 	va_end(ap);
 }
 
 void
-v(int is_croak, int use_errno, int exit_code, const char *fmt, va_list ap)
+v(int use_errno, int exit_code, const char *fmt, va_list ap)
 {
 	char msg[1024];
 	int len = 0;
@@ -42,8 +42,7 @@ v(int is_croak, int use_errno, int exit_code, const char *fmt, va_list ap)
 		snprintf(msg + len, sizeof(msg) - len, "%s%s",
 		    fmt ? ": " : "", strerror(use_errno));
 	log_error("%s", msg);
-	if (is_croak)
-		exit(exit_code);
+	exit(exit_code);
 }
 
 #if defined(__linux__)

--- a/sqe.h
+++ b/sqe.h
@@ -495,8 +495,8 @@ extern int oid_compare(struct ber *aa, struct ber *bb);
 
 /* other locations */
 const char *thisprogname(void);
-void croak(int exit_code, const char *fmt, ...);
-void croakx(int exit_code, const char *fmt, ...);
+void croak(int exit_code, const char *fmt, ...) __attribute__((noreturn));
+void croakx(int exit_code, const char *fmt, ...) __attribute__((noreturn));
 
 /* event_loop.c */
 struct socket_info *new_socket_info(int fd);


### PR DESCRIPTION
`croak()`/`croakx()` always `exit()` but were not declared noreturn, so clang's static analyzer assumed execution continues past every `if (!x) croak(...)` guard and reported ~23 false null-dereference/Unix-API findings across the codebase.

Declare both `__attribute__((noreturn))` in sqe.h. The static helper `v()` now exits unconditionally and carries the attribute itself; its `is_croak` parameter was meaningless (both callers always passed 1) and is gone. No behavior change.

Part of a series driving `scan-build make` to "No bugs found."

## Test plan

- [x] `make clean && make` — clean under `-Wall -Werror`
- [x] `make test` — 295/295 pass
- [x] `scan-build make`: findings drop 29 -> 6 (survivors addressed in sibling PRs)
