### PR TITLE
fix: separate error cases in snmp_send, drop dead stores, guard send queue

### DIFF
--- a/event_loop.c
+++ b/event_loop.c
@@ -106,6 +106,8 @@ flush_buffers(struct socket_info *si)
 			croakx(2, "flush_buffers: send_bufs queue unexpectedly empty");
 		if (n >= sb->size - sb->offset) {
 			TAILQ_REMOVE(&si->send_bufs, sb, send_list);
+			if (TAILQ_FIRST(&si->send_bufs) == sb)
+				croakx(2, "flush_buffers: send_bufs queue is corrupted");
 			n -= sb->size - sb->offset;
 			free(sb->buf);
 			free(sb);

--- a/main.c
+++ b/main.c
@@ -73,7 +73,6 @@ main(int argc, char **argv)
 		}
 	}
 	argc -= optind;
-	argv += optind;
 	if (argc != 0)
 		usage("extraneous arguments");
 

--- a/request_common.c
+++ b/request_common.c
@@ -107,7 +107,7 @@ msgpack_pack_options(msgpack_packer *pk, struct client_requests_info *cri)
 	msgpack_pack_named_int(pk, "ignore_threshold", cri->dest->ignore_threshold);
 	msgpack_pack_named_int(pk, "ignore_duration", cri->dest->ignore_duration);
 	if (cri->v3) {
-		char *s = "";
+		char *s;
 		msgpack_pack_named_string(pk, "username", cri->v3->username);
 		msgpack_pack_named_hex_buffer(pk, "engineid", cri->v3->engine_id, cri->v3->engine_id_len);
 		switch (cri->v3->auth_proto) {

--- a/snmp.c
+++ b/snmp.c
@@ -384,22 +384,25 @@ create_snmp_socket(void)
 
 void snmp_send(struct destination *dest, struct ber *packet)
 {
+	ssize_t n;
+
 	destination_start_timing(dest);
 
 	dest->packets_on_the_wire++;
 	PS.packets_on_the_wire++;
 //fprintf(stderr, "%s: snmp_send->(%d)\n", inet_ntoa(dest->ip), dest->packets_on_the_wire);
-	if (sendto(snmp->fd, packet->buf, packet->len, 0,
+	n = sendto(snmp->fd, packet->buf, packet->len, 0,
 			   (struct sockaddr *)&dest->dest_addr,
-			   sizeof(dest->dest_addr))
-		!= packet->len)
-	{
+			   sizeof(dest->dest_addr));
+	if (n < 0) {
 		if (errno == EAGAIN) {
 			PS.udp_send_buffer_overflow++;
 			return;
 		}
 		croak(1, "snmp_send: sendto");
 	}
+	if (n != packet->len)
+		croakx(1, "snmp_send: short send");
 //fprintf(stderr, "UDP datagram of %d bytes sent to %s:%d\n", packet->len, inet_ntoa(dest->dest_addr.sin_addr), ntohs(dest->dest_addr.sin_port));
 //dump_buf(stderr, packet->buf, packet->len);
 


### PR DESCRIPTION
Remaining scan-build findings, none with observable impact in practice:

- `snmp_send()` tested `errno` after a `sendto()` that can return a short count without setting errno; the error (`n < 0`) and short-send cases are now distinct, so no stale errno is ever read.
- Two dead stores removed: `argv += optind` in main(), the `char *s = ""` initializer in `msgpack_pack_options()` (every switch path assigns `s`).
- `flush_buffers()` gains a queue-corruption `croakx` guard after `TAILQ_REMOVE`, stating the list invariant; this is also what lets the analyzer prove the drain loop free of use-after-free.

With the sibling PRs merged, `scan-build make` reports "No bugs found."

## Test plan

- [x] `make test` — 295/295 pass
- [x] `scan-build make` at integration: "No bugs found."
