### PR TITLE
feat: convert log output to structured logfmt lines

### DIFF
--- a/.changes/unreleased/Changed-20260705-134524.yaml
+++ b/.changes/unreleased/Changed-20260705-134524.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'logs: emit machine-parseable key=value lines'
+time: 2026-07-05T13:45:24.176743+02:00

--- a/carp.c
+++ b/carp.c
@@ -41,7 +41,7 @@ v(int use_errno, int exit_code, const char *fmt, va_list ap)
 	if (use_errno >= 0 && (size_t)len < sizeof(msg))
 		snprintf(msg + len, sizeof(msg) - len, "%s%s",
 		    fmt ? ": " : "", strerror(use_errno));
-	log_error("%s", msg);
+	log_error(msg, NULL);
 	exit(exit_code);
 }
 

--- a/client_input.c
+++ b/client_input.c
@@ -23,7 +23,7 @@ client_gone(struct socket_info *si)
 		msgpack_unpacker_destroy(&c->unpacker);
 		free(c);
 	}
-	log_info("client disconnect");
+	log_info("client disconnect", NULL);
 }
 
 static void
@@ -99,7 +99,7 @@ client_input(struct socket_info *si)
         case RT_SETOPT:
             ok = handle_setopt_request(si, cid, o);
             if (ok < 0) {
-                log_warn("there was a problem handling setopt");
+                log_warn("problem handling setopt", NULL);
                 msgpack_object_print(stderr, *o);
             }
             break;

--- a/client_input.c
+++ b/client_input.c
@@ -99,7 +99,7 @@ client_input(struct socket_info *si)
         case RT_SETOPT:
             ok = handle_setopt_request(si, cid, o);
             if (ok < 0) {
-                log_warn("problem handling setopt", NULL);
+                log_warn("problem handling setopt", "cid", U(cid), NULL);
                 msgpack_object_print(stderr, *o);
             }
             break;

--- a/client_listen.c
+++ b/client_listen.c
@@ -18,7 +18,7 @@ do_accept(struct socket_info *lsi)
 	len = sizeof(addr);
 	if ( (fd = accept(lsi->fd, (struct sockaddr *)&addr, &len)) < 0)
 		croak(1, "do_accept: accept");
-	log_info("incoming connection from %s!", inet_ntoa(addr.sin_addr));
+	log_info("incoming connection", "peer", inet_ntoa(addr.sin_addr), NULL);
 	new_client_connection(fd);
 }
 

--- a/event_loop.c
+++ b/event_loop.c
@@ -71,7 +71,7 @@ flush_buffers(struct socket_info *si)
 	int i, n, tot;
 
 	if (!si->n_send_bufs) {
-		log_warn("flush_buffers: fd %d: unexpectedly nothing to flush", si->fd);
+		log_warn("nothing to flush", "fd", U((unsigned)si->fd), "op", "flush_buffers", NULL);
 		on_write(si, NULL);
 		return;
 	}
@@ -90,11 +90,11 @@ flush_buffers(struct socket_info *si)
 	if ( (n = writev(si->fd, io_buf, i)) < 0) {
 		switch (errno) {
 		case EPIPE:
-			log_warn("flush_buffers: EPIPE during writev");
+			log_warn("EPIPE during write", "op", "flush_buffers", NULL);
 			if (si->eof_handler)	si->eof_handler(si);
 			return;
 		case ECONNRESET:
-			log_warn("flush_buffers: ECONNRESET during writev");
+			log_warn("ECONNRESET during write", "op", "flush_buffers", NULL);
 			if (si->eof_handler)	si->eof_handler(si);
 			return;
 		}
@@ -343,7 +343,7 @@ begin_shutdown(void)
 	shutdown_active = 1;
 	gettimeofday(&shutdown_started, NULL);
 	notify("STOPPING=1");
-	log_info("shutting down on signal");
+	log_info("shutting down", NULL);
 	if (listener_si) {
 		delete_socket_info(listener_si);
 		listener_si = NULL;
@@ -379,7 +379,7 @@ event_loop(void)
 	int nev, i, ms, wd;
 	struct timespec to;
 
-	log_info("kqueue event loop started");
+	log_info("event loop started", "op", "kqueue", NULL);
 	while (1) {
 		ms = ms_to_next_timer();
 		wd = notify_watchdog_interval_ms();
@@ -407,13 +407,13 @@ event_loop(void)
 						if (si->eof_handler) {
 							si->eof_handler(si);
 						} else {
-							log_error("event_loop: EVFILT_READ: ident %u - socket does not have an eof handler", (unsigned)ke[i].ident);
+							log_error("socket missing handler", "fd", U((unsigned)ke[i].ident), "op", "read_eof", NULL);
 						}
 					} else {
 						if (si->read_handler) {
 							si->read_handler(si);
 						} else {
-							log_error("event_loop: EVFILT_READ: ident %u - socket does not have a read handler", (unsigned)ke[i].ident);
+							log_error("socket missing handler", "fd", U((unsigned)ke[i].ident), "op", "read", NULL);
 						}
 					}
 				}
@@ -425,18 +425,19 @@ event_loop(void)
 						if (si->eof_handler) {
 							si->eof_handler(si);
 						} else {
-							log_error("event_loop: EVFILT_WRITE: ident %u - socket does not have an eof handler", (unsigned)ke[i].ident);
+							log_error("socket missing handler", "fd", U((unsigned)ke[i].ident), "op", "write_eof", NULL);
 						}
 					} else {
 						if (si->write_handler) {
 							si->write_handler(si);
 						} else {
-							log_error("event_loop: EVFILT_WRITE: ident %u - socket does not have a write handler", (unsigned)ke[i].ident);
+							log_error("socket missing handler", "fd", U((unsigned)ke[i].ident), "op", "write", NULL);
 						}
 					}
 				}
 			} else {
-				log_error("event_loop: unexpected filter value %d, ident %u", ke[i].filter, (unsigned)ke[i].ident);
+				log_error("unexpected kqueue filter", "filter", I(ke[i].filter),
+				    "fd", U((unsigned)ke[i].ident), NULL);
 			}
 		}
 		trigger_timers();
@@ -452,7 +453,7 @@ event_loop(void)
 {
 	struct epoll_event ev[10];
 	int nev, i, ms, wd;
-	log_info("epoll event loop started");
+	log_info("event loop started", "op", "epoll", NULL);
 	while (1) {
 		ms = ms_to_next_timer();
 		wd = notify_watchdog_interval_ms();
@@ -477,7 +478,7 @@ event_loop(void)
 					if (si->read_handler) {
 						si->read_handler(si);
 					} else {
-						log_error("event_loop: EPOLLIN: fd %u - socket does not have a read handler", (unsigned)ev[i].data.fd);
+						log_error("socket missing handler", "fd", U((unsigned)ev[i].data.fd), "op", "epollin", NULL);
 					}
 				}
 			}
@@ -488,12 +489,13 @@ event_loop(void)
 					if (si->write_handler) {
 						si->write_handler(si);
 					} else {
-						log_error("event_loop: EPOLLOUT: fd %u - socket does not have a write handler", (unsigned)ev[i].data.fd);
+						log_error("socket missing handler", "fd", U((unsigned)ev[i].data.fd), "op", "epollout", NULL);
 					}
 				}
 			}
 			if (!(ev[i].events & (EPOLLIN|EPOLLOUT))) {
-				log_error("event_loop: unexpected event 0x%x, fd %u", ev[i].events, (unsigned)ev[i].data.fd);
+				log_error("unexpected epoll event", "event", HEX(ev[i].events),
+				    "fd", U((unsigned)ev[i].data.fd), NULL);
 			}
 		}
 		trigger_timers();

--- a/log.c
+++ b/log.c
@@ -86,7 +86,7 @@ log_format(char *out, size_t outsz, enum log_level lvl, int journal_mode,
 	size_t p = 0, i;
 
 #define APPEND(...) do { \
-	int _r = snprintf(out + p, p < outsz ? outsz - p : 0, __VA_ARGS__); \
+	int _r = snprintf(out + (p < outsz ? p : outsz), p < outsz ? outsz - p : 0, __VA_ARGS__); \
 	if (_r > 0) p += (size_t)_r; \
 } while (0)
 
@@ -103,6 +103,8 @@ log_format(char *out, size_t outsz, enum log_level lvl, int journal_mode,
 	}
 	APPEND("\n");
 #undef APPEND
+	if (p >= outsz && outsz >= 2)
+		out[outsz - 2] = '\n';
 	return (int)p;
 }
 

--- a/log.c
+++ b/log.c
@@ -102,37 +102,38 @@ log_format(char *out, size_t outsz, enum log_level lvl, int journal_mode,
 	return (int)p;
 }
 
-int
-log_line(char *out, size_t outsz, enum log_level lvl, int jmode,
-    const char *stamp, const char *msg)
+#define LOG_MAXFIELDS 16
+#define LOG_LINESZ 8192
+
+static void
+log_vemit(enum log_level lvl, const char *msg, va_list ap)
 {
-	static const char *name[] = { "error", "warn", "info", "debug" };
-	static const int prio[] = { 3, 4, 6, 7 };
+	struct log_field f[LOG_MAXFIELDS];
+	size_t n = 0;
+	const char *k;
+	char line[LOG_LINESZ];
 
-	if (jmode)
-		return snprintf(out, outsz, "<%d>%s\n", prio[lvl], msg);
-	return snprintf(out, outsz, "%s %s: %s\n", stamp, name[lvl], msg);
-}
-
-void
-log_vemit(enum log_level lvl, const char *fmt, va_list ap)
-{
-	char msg[1024], line[1200];
-
-	if (lvl > opt_log_level)
+	if (!log_wants(lvl))
 		return;
-	vsnprintf(msg, sizeof(msg), fmt, ap);
-	log_line(line, sizeof(line), lvl, journal_mode, timestring(), msg);
+	while ((k = va_arg(ap, const char *)) != NULL) {
+		const char *v = va_arg(ap, const char *);
+		if (n < LOG_MAXFIELDS) {
+			f[n].k = k;
+			f[n].v = v;
+			n++;
+		}
+	}
+	log_format(line, sizeof(line), lvl, journal_mode, timestring(), msg, f, n);
 	fputs(line, stderr);
 }
 
 #define LOG_FUNC(fn, lvl) \
 void \
-fn(const char *fmt, ...) \
+fn(const char *msg, ...) \
 { \
 	va_list ap; \
-	va_start(ap, fmt); \
-	log_vemit(lvl, fmt, ap); \
+	va_start(ap, msg); \
+	log_vemit(lvl, msg, ap); \
 	va_end(ap); \
 }
 

--- a/log.c
+++ b/log.c
@@ -66,6 +66,43 @@ log_enc(char *out, size_t outsz, const char *val)
 }
 
 int
+log_wants(enum log_level lvl)
+{
+	return lvl <= opt_log_level;
+}
+
+int
+log_format(char *out, size_t outsz, enum log_level lvl, int journal_mode,
+    const char *stamp, const char *msg,
+    const struct log_field *fields, size_t nfields)
+{
+	static const char *name[] = { "error", "warn", "info", "debug" };
+	static const int prio[] = { 3, 4, 6, 7 };
+	char enc[512];
+	size_t p = 0, i;
+
+#define APPEND(...) do { \
+	int _r = snprintf(out + p, p < outsz ? outsz - p : 0, __VA_ARGS__); \
+	if (_r > 0) p += (size_t)_r; \
+} while (0)
+
+	if (journal_mode) {
+		APPEND("<%d>", prio[lvl]);
+	} else {
+		APPEND("time=%s level=%s ", stamp, name[lvl]);
+	}
+	log_enc(enc, sizeof(enc), msg);
+	APPEND("msg=%s", enc);
+	for (i = 0; i < nfields; i++) {
+		log_enc(enc, sizeof(enc), fields[i].v);
+		APPEND(" %s=%s", fields[i].k, enc);
+	}
+	APPEND("\n");
+#undef APPEND
+	return (int)p;
+}
+
+int
 log_line(char *out, size_t outsz, enum log_level lvl, int jmode,
     const char *stamp, const char *msg)
 {

--- a/log.c
+++ b/log.c
@@ -20,6 +20,51 @@ log_setup(void)
 	}
 }
 
+static int
+needs_quote(const char *s)
+{
+	if (!*s)
+		return 1;
+	for (const unsigned char *p = (const unsigned char *)s; *p; p++)
+		if (*p == ' ' || *p == '=' || *p == '"' || *p == '\\' || *p < 0x20)
+			return 1;
+	return 0;
+}
+
+size_t
+log_enc(char *out, size_t outsz, const char *val)
+{
+	size_t n = 0;
+	if (outsz == 0)
+		return 0;
+	if (!needs_quote(val)) {
+		while (val[n] && n + 1 < outsz) {
+			out[n] = val[n];
+			n++;
+		}
+		out[n] = '\0';
+		return n;
+	}
+	/* quoted form */
+#define PUT(c) do { if (n + 1 < outsz) out[n++] = (c); } while (0)
+	PUT('"');
+	for (const unsigned char *p = (const unsigned char *)val; *p; p++) {
+		unsigned char c = *p;
+		if (c == '"' || c == '\\') { PUT('\\'); PUT(c); }
+		else if (c == '\n') { PUT('\\'); PUT('n'); }
+		else if (c == '\t') { PUT('\\'); PUT('t'); }
+		else if (c == '\r') { PUT('\\'); PUT('r'); }
+		else if (c < 0x20) {
+			static const char hexd[] = "0123456789abcdef";
+			PUT('\\'); PUT('x'); PUT(hexd[c >> 4]); PUT(hexd[c & 0xf]);
+		} else PUT(c);
+	}
+	PUT('"');
+#undef PUT
+	out[n < outsz ? n : outsz - 1] = '\0';
+	return n;
+}
+
 int
 log_line(char *out, size_t outsz, enum log_level lvl, int jmode,
     const char *stamp, const char *msg)

--- a/log.c
+++ b/log.c
@@ -103,3 +103,57 @@ LOG_FUNC(log_error, LL_ERROR)
 LOG_FUNC(log_warn, LL_WARN)
 LOG_FUNC(log_info, LL_INFO)
 LOG_FUNC(log_debug, LL_DEBUG)
+
+#define RING_SLOTS 8
+#define RING_SLOTSZ 32
+static char ring[RING_SLOTS][RING_SLOTSZ];
+static int ring_idx;
+
+static char *
+ring_next(void)
+{
+	char *s = ring[ring_idx];
+	ring_idx = (ring_idx + 1) % RING_SLOTS;
+	return s;
+}
+
+const char *
+log_u(unsigned v)
+{
+	char *s = ring_next();
+	snprintf(s, RING_SLOTSZ, "%u", v);
+	return s;
+}
+
+const char *
+log_i(int v)
+{
+	char *s = ring_next();
+	snprintf(s, RING_SLOTSZ, "%d", v);
+	return s;
+}
+
+const char *
+log_hex(unsigned v)
+{
+	char *s = ring_next();
+	snprintf(s, RING_SLOTSZ, "0x%x", v);
+	return s;
+}
+
+#define HEXBUF_MAX_IN 4096
+static char hexbuf_buf[2 * HEXBUF_MAX_IN + 1];
+
+const char *
+log_hexbuf(const void *buf, size_t len)
+{
+	static const char hexd[] = "0123456789abcdef";
+	const unsigned char *b = buf;
+	size_t i, n = len > HEXBUF_MAX_IN ? HEXBUF_MAX_IN : len;
+	for (i = 0; i < n; i++) {
+		hexbuf_buf[2 * i]     = hexd[b[i] >> 4];
+		hexbuf_buf[2 * i + 1] = hexd[b[i] & 0xf];
+	}
+	hexbuf_buf[2 * n] = '\0';
+	return hexbuf_buf;
+}

--- a/log.c
+++ b/log.c
@@ -71,6 +71,10 @@ log_wants(enum log_level lvl)
 	return lvl <= opt_log_level;
 }
 
+/* Largest legitimate field value is a HEXBUF() dump: HEXBUF_MAX_IN input
+ * bytes hex-encoded to twice that many chars, plus a NUL. */
+#define HEXBUF_MAX_IN 4096
+
 int
 log_format(char *out, size_t outsz, enum log_level lvl, int journal_mode,
     const char *stamp, const char *msg,
@@ -78,7 +82,7 @@ log_format(char *out, size_t outsz, enum log_level lvl, int journal_mode,
 {
 	static const char *name[] = { "error", "warn", "info", "debug" };
 	static const int prio[] = { 3, 4, 6, 7 };
-	char enc[512];
+	static char enc[2 * HEXBUF_MAX_IN + 1];
 	size_t p = 0, i;
 
 #define APPEND(...) do { \
@@ -179,7 +183,6 @@ log_hex(unsigned v)
 	return s;
 }
 
-#define HEXBUF_MAX_IN 4096
 static char hexbuf_buf[2 * HEXBUF_MAX_IN + 1];
 
 const char *

--- a/log.h
+++ b/log.h
@@ -1,5 +1,5 @@
 /* ABOUTME: Leveled logging API: severity enum, pure line formatter, and
- * ABOUTME: printf-style emitters used by every diagnostic in the daemon. */
+ * ABOUTME: logfmt key-value emitters used by every diagnostic in the daemon. */
 #ifndef SQE_LOG_H
 #define SQE_LOG_H
 
@@ -19,13 +19,10 @@ int log_format(char *out, size_t outsz, enum log_level lvl, int journal_mode,
     const char *stamp, const char *msg,
     const struct log_field *fields, size_t nfields);
 
-int log_line(char *out, size_t outsz, enum log_level lvl, int journal_mode,
-    const char *stamp, const char *msg);
-void log_vemit(enum log_level lvl, const char *fmt, va_list ap);
-void log_error(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void log_warn(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void log_info(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-void log_debug(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void log_error(const char *msg, ...) __attribute__((sentinel));
+void log_warn (const char *msg, ...) __attribute__((sentinel));
+void log_info (const char *msg, ...) __attribute__((sentinel));
+void log_debug(const char *msg, ...) __attribute__((sentinel));
 const char *log_u(unsigned v);
 const char *log_i(int v);
 const char *log_hex(unsigned v);

--- a/log.h
+++ b/log.h
@@ -11,6 +11,7 @@ enum log_level { LL_ERROR, LL_WARN, LL_INFO, LL_DEBUG };
 extern enum log_level opt_log_level;
 
 void log_setup(void);
+size_t log_enc(char *out, size_t outsz, const char *val);
 int log_line(char *out, size_t outsz, enum log_level lvl, int journal_mode,
     const char *stamp, const char *msg);
 void log_vemit(enum log_level lvl, const char *fmt, va_list ap);

--- a/log.h
+++ b/log.h
@@ -12,6 +12,13 @@ extern enum log_level opt_log_level;
 
 void log_setup(void);
 size_t log_enc(char *out, size_t outsz, const char *val);
+int log_wants(enum log_level lvl);
+
+struct log_field { const char *k, *v; };
+int log_format(char *out, size_t outsz, enum log_level lvl, int journal_mode,
+    const char *stamp, const char *msg,
+    const struct log_field *fields, size_t nfields);
+
 int log_line(char *out, size_t outsz, enum log_level lvl, int journal_mode,
     const char *stamp, const char *msg);
 void log_vemit(enum log_level lvl, const char *fmt, va_list ap);

--- a/log.h
+++ b/log.h
@@ -19,5 +19,13 @@ void log_error(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void log_warn(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void log_info(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 void log_debug(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+const char *log_u(unsigned v);
+const char *log_i(int v);
+const char *log_hex(unsigned v);
+const char *log_hexbuf(const void *buf, size_t len);
+#define U(x)        log_u(x)
+#define I(x)        log_i(x)
+#define HEX(x)      log_hex(x)
+#define HEXBUF(b,l) log_hexbuf((b), (l))
 
 #endif

--- a/main.c
+++ b/main.c
@@ -77,7 +77,7 @@ main(int argc, char **argv)
 		usage("extraneous arguments");
 
 	log_setup();
-	log_debug("debug logging enabled");
+	log_debug("debug logging enabled", NULL);
 
 	signal(SIGPIPE, SIG_IGN);
 	signal(SIGHUP, SIG_IGN);
@@ -92,7 +92,7 @@ main(int argc, char **argv)
 	notify_init();
 
     if (populate_well_known_oids() < 0) {
-        log_error("unable to populate well-known oids: %s", strerror(errno));
+        log_error("unable to populate well-known oids", "error", strerror(errno), NULL);
         exit(1);
     }
 
@@ -101,7 +101,7 @@ main(int argc, char **argv)
 	notify("READY=1");
 	event_loop();
 
-	log_info("shutdown complete");
+	log_info("shutdown complete", NULL);
 	return 0;
 }
 

--- a/notify.c
+++ b/notify.c
@@ -28,7 +28,7 @@ notify_init(void)
 		notify_addr.sun_path[0] = '\0';
 	notify_addrlen = offsetof(struct sockaddr_un, sun_path) + len;
 	if ( (notify_fd = socket(AF_UNIX, SOCK_DGRAM, 0)) < 0) {
-		log_debug("notify_init: socket: %s", strerror(errno));
+		log_debug("notify socket unavailable", "error", strerror(errno), NULL);
 		return;
 	}
 	if (usec && (!wpid || atoi(wpid) == (int)getpid())) {
@@ -46,7 +46,7 @@ notify(const char *state)
 		return;
 	if (sendto(notify_fd, state, strlen(state), 0,
 	    (struct sockaddr *)&notify_addr, notify_addrlen) < 0)
-		log_debug("notify: sendto: %s", strerror(errno));
+		log_debug("notify sendto failed", "error", strerror(errno), NULL);
 }
 
 void

--- a/oid_info.c
+++ b/oid_info.c
@@ -16,8 +16,9 @@ free_oid_info_list(struct oid_info_head *list)
 	n1 = TAILQ_FIRST(list);
 	while (n1 != NULL) {
 		n2 = TAILQ_NEXT(n1, oid_list);
-		log_debug("freeing oid", "cid", U(n1->cid), "sid", U(n1->sid),
-		    "oid", oid2str(n1->oid), NULL);
+		if (log_wants(LL_DEBUG))
+			log_debug("freeing oid", "cid", U(n1->cid), "sid", U(n1->sid),
+			    "oid", oid2str(n1->oid), NULL);
 		free(n1->oid.buf);
 		free(n1->value.buf);
 		PS.active_oid_infos--;

--- a/oid_info.c
+++ b/oid_info.c
@@ -16,9 +16,8 @@ free_oid_info_list(struct oid_info_head *list)
 	n1 = TAILQ_FIRST(list);
 	while (n1 != NULL) {
 		n2 = TAILQ_NEXT(n1, oid_list);
-if (0){
-log_debug("       freeing an oid (C:%u,S:%u) %s", n1->cid, n1->sid, oid2str(n1->oid));
-}
+		log_debug("freeing oid", "cid", U(n1->cid), "sid", U(n1->sid),
+		    "oid", oid2str(n1->oid), NULL);
 		free(n1->oid.buf);
 		free(n1->value.buf);
 		PS.active_oid_infos--;

--- a/request_setopt.c
+++ b/request_setopt.c
@@ -312,8 +312,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
                              &v3.authkul_len,
                              &err))
 		{
-            log_warn("handle_setopt_request: authkul calculation error: "
-                    "password_to_kul: %s", err);
+            log_warn("authkul calculation error", NULL);
             return error_reply(si, RT_SETOPT | RT_ERROR, cid, "authpass to kul calculation error");
         }
     }
@@ -331,8 +330,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
                              &v3.privkul_len,
                              &err))
 		{
-            log_warn("handle_setopt_request: privkul calculation error: "
-                    "password_to_kul: %s", err);
+            log_warn("privkul calculation error", NULL);
             return error_reply(si, RT_SETOPT | RT_ERROR, cid, "privpass to kul calculation error");
         }
 
@@ -347,8 +345,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
                         &v3.x_privkul_len,
                         &err))
 		{
-            log_warn("handle_setopt_request: privkul calculation error: "
-                    "expand_kul: %s", err);
+            log_warn("privkul calculation error", NULL);
             return error_reply(si, RT_SETOPT | RT_ERROR, cid, "expand kul calculation error");
         }
     }
@@ -367,8 +364,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
                         &v3.x_privkul_len,
                         &err))
 		{
-            log_warn("handle_setopt_request: x_privkul calculation error: "
-                    "expand_kul: %s", err);
+            log_warn("x_privkul calculation error", NULL);
             return error_reply(si, RT_SETOPT | RT_ERROR, cid, "x_privkul calculation error");
         }
 	}

--- a/request_setopt.c
+++ b/request_setopt.c
@@ -312,7 +312,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
                              &v3.authkul_len,
                              &err))
 		{
-            log_warn("authkul calculation error", NULL);
+            log_warn("authkul calculation error", "cid", U(cid), "error", err, NULL);
             return error_reply(si, RT_SETOPT | RT_ERROR, cid, "authpass to kul calculation error");
         }
     }
@@ -330,7 +330,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
                              &v3.privkul_len,
                              &err))
 		{
-            log_warn("privkul calculation error", NULL);
+            log_warn("privkul calculation error", "cid", U(cid), "error", err, NULL);
             return error_reply(si, RT_SETOPT | RT_ERROR, cid, "privpass to kul calculation error");
         }
 
@@ -345,7 +345,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
                         &v3.x_privkul_len,
                         &err))
 		{
-            log_warn("privkul calculation error", NULL);
+            log_warn("privkul calculation error", "cid", U(cid), "error", err, NULL);
             return error_reply(si, RT_SETOPT | RT_ERROR, cid, "expand kul calculation error");
         }
     }
@@ -364,7 +364,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
                         &v3.x_privkul_len,
                         &err))
 		{
-            log_warn("x_privkul calculation error", NULL);
+            log_warn("x_privkul calculation error", "cid", U(cid), "error", err, NULL);
             return error_reply(si, RT_SETOPT | RT_ERROR, cid, "x_privkul calculation error");
         }
 	}

--- a/sid_info.c
+++ b/sid_info.c
@@ -450,7 +450,7 @@ process_sid_info_response(struct sid_info *si, struct ber *e)
 		}
 	} else {
 		if (!TAILQ_EMPTY(&si->oids_being_queried)) {
-			log_warn("SID %u: unexpectedly, not all oids are accounted for!", si->sid);
+			log_warn("not all oids accounted for", "sid", U(si->sid), NULL);
 			all_oids_done(si, &BER_MISSING);
 		}
 	}
@@ -463,7 +463,7 @@ process_sid_info_response(struct sid_info *si, struct ber *e)
 	return 1;
 bad_snmp_packet:
 	PS.bad_snmp_responses++;
-	log_warn("sid %u: bad SNMP packet, ignoring: %s", si->sid, trace);
+	log_warn("bad SNMP packet, ignoring", "sid", U(si->sid), "trace", trace, NULL);
 	return 0;
 }
 

--- a/snmp.c
+++ b/snmp.c
@@ -23,14 +23,15 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 	char *trace;
 	struct destination *dest;
 	struct sid_info *si;
-	char log[256];
+	char peer[64];
 
-	snprintf(log, sizeof(log), "%s:%d", inet_ntoa(from->sin_addr), ntohs(from->sin_port));
+	snprintf(peer, sizeof(peer), "%s:%d", inet_ntoa(from->sin_addr),
+	    ntohs(from->sin_port));
 
 	PS.octets_received += n;
 	dest = find_destination(&from->sin_addr, ntohs(from->sin_port));
 	if (!dest) {
-		log_warn("%s: destination is not known, ignoring packet", log);
+		log_warn("destination not known, ignoring packet", "peer", peer, NULL);
 		return;
 	}
 	dest->octets_received += n;
@@ -60,11 +61,9 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 		CHECK("PDU", decode_composite(e, PDU_GET_RESPONSE, NULL));
 		CHECK("request id", decode_integer(e, -1, &sid));
 
-		snprintf(log, sizeof(log), "%s:%d[%u]", inet_ntoa(from->sin_addr), ntohs(from->sin_port), sid);
-
 		si = find_sid_info(dest, sid);
 		if (!si) {
-			log_info("%s: late reply, ignoring packet", log);
+			log_info("late reply, ignoring packet", "peer", peer, "sid", U(sid), NULL);
 			return;
 		}
 
@@ -87,7 +86,6 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
         CHECK("msgGlobalData sequence", decode_sequence(e, NULL));
 		CHECK("msgID", decode_integer(e, -1, &mid));
-		snprintf(log, sizeof(log), "%s:%d[%u]", inet_ntoa(from->sin_addr), ntohs(from->sin_port), mid);
 		CHECK("msgMaxSize", decode_integer(e, -1, &v3.msg_max_size));
 		CHECK("msgFlags", decode_octets(e, &v3.msg_flags, 1, &msg_flags_len));
 		if (msg_flags_len != 1) {
@@ -123,14 +121,14 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
 		si = find_sid_info(dest, mid);
 		if (!si) {
-			log_info("%s: late reply, ignoring packet", log);
+			log_info("late reply, ignoring packet", "peer", peer, "mid", U(mid), NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
 		}
 
 		// - ignore if no si->v3 setup
 		if (si->cri->version != 3 || !si->cri->v3) {
-			log_warn("%s: si->cri is not a V3, or no V3 info found, ignoring packet", log);
+			log_warn("no v3 info for reply, ignoring packet", "peer", peer, "mid", U(mid), NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
 		}
@@ -150,17 +148,16 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 				p += snprintf(known+p, sizeof(known)-p, "%02x", siv3->engine_id[i]);
 			for (p = 0, i = 0; i < v3.engine_id_len; i++)
 				p += snprintf(received+p, sizeof(received)-p, "%02x", v3.engine_id[i]);
-			log_warn("%s: known engine-id %s does not match received engine-id %s, ignoring packet",
-					log, known, received);
+			log_warn("engine-id mismatch, ignoring packet", "peer", peer,
+					"known_engine_id", known, "recv_engine_id", received, NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
         }
 
 		// - verify username
 		if (strcmp(siv3->username, v3.username) != 0) {
-			log_warn("%s: known username \"%s\" does not match "
-					"received username \"%s\", ignoring packet",
-					log, siv3->username, v3.username);
+			log_warn("username mismatch, ignoring packet", "peer", peer,
+					"known_username", siv3->username, "username", v3.username, NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
 		}
@@ -180,18 +177,21 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 			memset(auth_param_ptr, 0, maclen); // clear original HMAC location for auth calculations
     		if (hmac_message(siv3, auth_param_ptr, maclen, e->buf, e->max_len, auth_param_ptr) < 0) {
 				memcpy(auth_param_ptr, auth_param, maclen);
-				log_warn("%s: authentication failed: %s, prepare for packet dump:",
-						log, strerror(errno));
-				dump_buf(stderr, e->buf, e->max_len);
+				log_warn("authentication failed", "peer", peer, "error", strerror(errno), NULL);
+				log_debug("authentication failed", "peer", peer,
+						"packet", HEXBUF(e->buf, e->max_len), NULL);
 				trace = NULL;
 				goto bad_snmp_packet;
 			}
 			if (memcmp(auth_param_ptr, auth_param, maclen) != 0) {
-				log_warn("%s: authentication failed, calculated digest:", log);
-				dump_buf(stderr, auth_param_ptr, maclen);
+				char auth_calc[2 * EVP_MAX_MD_SIZE + 1];
+
+				snprintf(auth_calc, sizeof(auth_calc), "%s", HEXBUF(auth_param_ptr, maclen));
 				memcpy(auth_param_ptr, auth_param, maclen);
-				log_warn("prepare for packet dump:");
-				dump_buf(stderr, e->buf, e->max_len);
+				log_warn("authentication failed", "peer", peer, NULL);
+				log_debug("authentication failed", "peer", peer,
+						"auth_calc", auth_calc,
+						"packet", HEXBUF(e->buf, e->max_len), NULL);
 				trace = NULL;
 				goto bad_snmp_packet;
 			}
@@ -208,7 +208,7 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
         	if (t != AT_STRING) goto bad_snmp_packet;
 			// - decrypt
 			if (decrypt_in_place(e->b, l, priv_param, siv3) < 0) {
-				log_warn("%s: cannot decrypt, ignoring packet", log);
+				log_warn("cannot decrypt, ignoring packet", "peer", peer, NULL);
 				trace = NULL;
 				goto bad_snmp_packet;
 			}
@@ -227,8 +227,8 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 				p += snprintf(authoritative+p, sizeof(authoritative)-p, "%02x", v3.engine_id[i]);
 			for (p = 0, i = 0; i < l; i++)
 				p += snprintf(context+p, sizeof(context)-p, "%02x", context_engine_id[i]);
-			log_warn("%s: authoritative-engine-id %s does not match context-engine-id %s, ignoring packet",
-					log, authoritative, context);
+			log_warn("authoritative/context engine-id mismatch, ignoring packet", "peer", peer,
+					"auth_engine_id", authoritative, "context_engine_id", context, NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
         }
@@ -246,7 +246,7 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 		}
 		t = e->b[0];
 		if (t != PDU_REPORT && t != PDU_GET_RESPONSE) {
-			log_warn("%s: unsupported PDU type %x, ignoring packet", log, t);
+			log_warn("unsupported PDU type, ignoring packet", "peer", peer, "pdu_type", HEX(t), NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
 		}
@@ -258,8 +258,8 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 			// if our request HMAC is wrong, some implementations return 0x7fffffff
 			// to be on the safe side, we generally ignore sid != mid situation
 			if (sid != 0x7fffffff)
-				log_warn("%s: warning: message-id %u does not match request-id %u",
-						log, mid, sid);
+				log_warn("message-id does not match request-id", "peer", peer,
+						"mid", U(mid), "sid", U(sid), NULL);
 		}
 
 		// - if it's a report, make sure re-sending is done ASAP and no timeout counter increases
@@ -270,11 +270,11 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
 			CHECK("error-status", decode_integer(e, -1, &error_status));
 			if (error_status != 0) {
-				log_warn("%s: warning: non-zero error-status (%d)", log, error_status);
+				log_warn("non-zero error-status", "peer", peer, "error_status", I(error_status), NULL);
 			}
 			CHECK("error-index", decode_integer(e, -1, &error_index));
 			if (error_index != 0) {
-				log_warn("%s: warning: non-zero error-index (%d)", log, error_index);
+				log_warn("non-zero error-index", "peer", peer, "error_index", I(error_index), NULL);
 			}
 
 			// - analyze varbinds and report
@@ -292,12 +292,13 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 					resend_query_with_new_sid(si);
 					return;
 				} else if (oid_compare(&oid, &usmStatsWrongDigests) == 0) {
-					log_warn("%s: report: our request had bad digest, ignoring packet", log);
+					log_warn("report: bad digest, ignoring packet", "peer", peer, NULL);
 					trace = NULL;
 					goto bad_snmp_packet;
 				} else {
-					log_warn("%s: report: %s:", log, oid2str(oid));
-					ber_dump(stderr, &val);
+					log_warn("report", "peer", peer, "oid", oid2str(oid), NULL);
+					log_debug("report", "peer", peer,
+							"value", HEXBUF(val.buf, (size_t)val.len), NULL);
 					trace = NULL;
 					goto bad_snmp_packet;
 				}
@@ -322,7 +323,7 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 bad_snmp_packet:
 	PS.bad_snmp_responses++;
 	if (trace)
-		log_warn("%s: bad SNMP packet, ignoring: %s", log, trace);
+		log_warn("bad SNMP packet, ignoring", "peer", peer, "trace", trace, NULL);
 	maybe_query_destination(dest);
 }
 

--- a/t/logging.t
+++ b/t/logging.t
@@ -24,11 +24,11 @@ subtest 'default level: info, plain format' => sub {
 	$d->request([RT_INFO, 1]);
 	$d->stop;
 	my $text = slurp("$log");
-	like($text, qr/^$TS info: (?:epoll|kqueue) event loop started$/m,
+	like($text, qr/^time=$TS level=info msg="event loop started" op=(?:epoll|kqueue)$/m,
 		'startup line at info with timestamp');
-	like($text, qr/^$TS info: .*incoming connection/m,
+	like($text, qr/^time=$TS level=info msg="incoming connection"/m,
 		'connection notice at info');
-	unlike($text, qr/ debug: /, 'no debug lines by default');
+	unlike($text, qr/level=debug/, 'no debug lines by default');
 };
 
 subtest '-q: warnings and errors only' => sub {
@@ -37,7 +37,7 @@ subtest '-q: warnings and errors only' => sub {
 	$d->request([RT_INFO, 1]);
 	$d->stop;
 	my $text = slurp("$log");
-	unlike($text, qr/ info: /, 'info suppressed under -q');
+	unlike($text, qr/level=info/, 'info suppressed under -q');
 };
 
 subtest '-d: debug enabled' => sub {
@@ -45,7 +45,7 @@ subtest '-d: debug enabled' => sub {
 	my $d = spawn_daemon(args => ['-d'], stderr_file => "$log");
 	$d->request([RT_INFO, 1]);
 	$d->stop;
-	like(slurp("$log"), qr/^$TS debug: debug logging enabled$/m,
+	like(slurp("$log"), qr/^time=$TS level=debug msg="debug logging enabled"$/m,
 		'debug line present under -d');
 };
 
@@ -57,7 +57,7 @@ subtest 'journald mode: <N> prefixes, no timestamps' => sub {
 	$d->request([RT_INFO, 1]);
 	$d->stop;
 	my $text = slurp("$log");
-	like($text, qr/^<6>(?:epoll|kqueue) event loop started$/m,
+	like($text, qr/^<6>msg="event loop started" op=(?:epoll|kqueue)$/m,
 		'info line carries <6> prefix');
 	unlike($text, qr/^$TS/m, 'no timestamps in journald mode');
 };

--- a/t/test_log.c
+++ b/t/test_log.c
@@ -24,6 +24,16 @@ is_enc(const char *val, const char *expected)
 		tap_diag("got: %s want: %s", buf, expected);
 }
 
+static void
+is_fmt(enum log_level lvl, int jmode, const char *stamp, const char *msg,
+    const struct log_field *f, size_t nf, const char *expected)
+{
+	char buf[512];
+	log_format(buf, sizeof(buf), lvl, jmode, stamp, msg, f, nf);
+	if (!ok(strcmp(buf, expected) == 0, "fmt: %s", expected))
+		tap_diag("got: %s", buf);
+}
+
 int
 main(void)
 {
@@ -60,5 +70,28 @@ main(void)
 		ok(strcmp(a, "1") == 0 && strcmp(b, "2") == 0 &&
 		   strcmp(c, "3") == 0 && strcmp(d, "4") == 0, "ring keeps 4 live");
 	}
+	{
+		struct log_field none[1];
+		is_fmt(LL_INFO, 0, "TS", "hello", none, 0,
+		    "time=TS level=info msg=hello\n");
+		is_fmt(LL_WARN, 1, "IGN", "hello", none, 0,
+		    "<4>msg=hello\n");
+		is_fmt(LL_INFO, 0, "TS", "two words", none, 0,
+		    "time=TS level=info msg=\"two words\"\n");
+	}
+	{
+		struct log_field f[] = {
+			{ "peer", "10.0.0.1:161" },
+			{ "sid",  "42" },
+			{ "trace", "decoding pdu" },
+		};
+		is_fmt(LL_WARN, 0, "TS", "bad packet", f, 3,
+		    "time=TS level=warn msg=\"bad packet\" "
+		    "peer=10.0.0.1:161 sid=42 trace=\"decoding pdu\"\n");
+		is_fmt(LL_WARN, 1, "IGN", "bad packet", f, 3,
+		    "<4>msg=\"bad packet\" peer=10.0.0.1:161 sid=42 "
+		    "trace=\"decoding pdu\"\n");
+	}
+	ok(log_wants(LL_ERROR) == 1, "wants error at default level");
 	return tap_done();
 }

--- a/t/test_log.c
+++ b/t/test_log.c
@@ -85,6 +85,18 @@ main(void)
 		if (!ok(strcmp(buf, expected) == 0, "long field value is not truncated"))
 			tap_diag("got len %zu want len %zu", strlen(buf), strlen(expected));
 	}
+	{
+		char longval[601];
+		char buf[64];
+		struct log_field f[] = { { "field", longval } };
+
+		memset(longval, 'a', sizeof(longval) - 1);
+		longval[sizeof(longval) - 1] = '\0';
+		log_format(buf, sizeof(buf), LL_INFO, 0, "TS", "hello", f, 1);
+		if (!ok(strlen(buf) == sizeof(buf) - 1 && buf[sizeof(buf) - 2] == '\n',
+		    "truncated line keeps trailing newline"))
+			tap_diag("got len %zu buf %s", strlen(buf), buf);
+	}
 	ok(log_wants(LL_ERROR) == 1, "wants error at default level");
 	return tap_done();
 }

--- a/t/test_log.c
+++ b/t/test_log.c
@@ -72,6 +72,19 @@ main(void)
 		    "<4>msg=\"bad packet\" peer=10.0.0.1:161 sid=42 "
 		    "trace=\"decoding pdu\"\n");
 	}
+	{
+		char longval[601];
+		char buf[8300], expected[8300];
+		struct log_field f[] = { { "field", longval } };
+
+		memset(longval, 'a', sizeof(longval) - 1);
+		longval[sizeof(longval) - 1] = '\0';
+		snprintf(expected, sizeof(expected),
+		    "time=TS level=info msg=hello field=%s\n", longval);
+		log_format(buf, sizeof(buf), LL_INFO, 0, "TS", "hello", f, 1);
+		if (!ok(strcmp(buf, expected) == 0, "long field value is not truncated"))
+			tap_diag("got len %zu want len %zu", strlen(buf), strlen(expected));
+	}
 	ok(log_wants(LL_ERROR) == 1, "wants error at default level");
 	return tap_done();
 }

--- a/t/test_log.c
+++ b/t/test_log.c
@@ -1,19 +1,7 @@
-/* ABOUTME: Unit tests for the log_line() formatter in log.c:
- * ABOUTME: journald priority-prefix mode vs plain timestamped mode. */
+/* ABOUTME: Unit tests for the log_enc() encoder and log_format() line
+ * ABOUTME: assembler in log.c: journald priority-prefix mode vs plain timestamped mode. */
 #include "../sqe.h"
 #include "tap.h"
-
-static void
-check_line(enum log_level lvl, int jmode, const char *stamp,
-    const char *msg, const char *expected)
-{
-	char buf[512];
-
-	log_line(buf, sizeof(buf), lvl, jmode, stamp, msg);
-	if (!ok(strcmp(buf, expected) == 0, "log_line(%d,%d,%s): %s",
-	    (int)lvl, jmode, stamp ? stamp : "-", expected))
-		tap_diag("got: %s", buf);
-}
 
 static void
 is_enc(const char *val, const char *expected)
@@ -37,14 +25,6 @@ is_fmt(enum log_level lvl, int jmode, const char *stamp, const char *msg,
 int
 main(void)
 {
-	check_line(LL_ERROR, 1, "IGNORED", "boom", "<3>boom\n");
-	check_line(LL_WARN,  1, "IGNORED", "eek",  "<4>eek\n");
-	check_line(LL_INFO,  1, "IGNORED", "hi",   "<6>hi\n");
-	check_line(LL_DEBUG, 1, "IGNORED", "dbg",  "<7>dbg\n");
-	check_line(LL_ERROR, 0, "STAMP", "boom", "STAMP error: boom\n");
-	check_line(LL_WARN,  0, "STAMP", "eek",  "STAMP warn: eek\n");
-	check_line(LL_INFO,  0, "STAMP", "hi",   "STAMP info: hi\n");
-	check_line(LL_DEBUG, 0, "STAMP", "dbg",  "STAMP debug: dbg\n");
 	is_enc("info",          "info");
 	is_enc("10.0.0.1:161",  "10.0.0.1:161");
 	is_enc("1.3.6.1.2.1",   "1.3.6.1.2.1");

--- a/t/test_log.c
+++ b/t/test_log.c
@@ -15,6 +15,15 @@ check_line(enum log_level lvl, int jmode, const char *stamp,
 		tap_diag("got: %s", buf);
 }
 
+static void
+is_enc(const char *val, const char *expected)
+{
+	char buf[256];
+	log_enc(buf, sizeof(buf), val);
+	if (!ok(strcmp(buf, expected) == 0, "enc(%s)", val))
+		tap_diag("got: %s want: %s", buf, expected);
+}
+
 int
 main(void)
 {
@@ -26,5 +35,17 @@ main(void)
 	check_line(LL_WARN,  0, "STAMP", "eek",  "STAMP warn: eek\n");
 	check_line(LL_INFO,  0, "STAMP", "hi",   "STAMP info: hi\n");
 	check_line(LL_DEBUG, 0, "STAMP", "dbg",  "STAMP debug: dbg\n");
+	is_enc("info",          "info");
+	is_enc("10.0.0.1:161",  "10.0.0.1:161");
+	is_enc("1.3.6.1.2.1",   "1.3.6.1.2.1");
+	is_enc("hello world",   "\"hello world\"");
+	is_enc("a=b",           "\"a=b\"");
+	is_enc("say \"hi\"",    "\"say \\\"hi\\\"\"");
+	is_enc("back\\slash",   "\"back\\\\slash\"");
+	is_enc("",              "\"\"");
+	is_enc("l1\nl2",        "\"l1\\nl2\"");
+	is_enc("t\tend",        "\"t\\tend\"");
+	is_enc("r\rend",        "\"r\\rend\"");
+	is_enc("\x01",          "\"\\x01\"");
 	return tap_done();
 }

--- a/t/test_log.c
+++ b/t/test_log.c
@@ -47,5 +47,18 @@ main(void)
 	is_enc("t\tend",        "\"t\\tend\"");
 	is_enc("r\rend",        "\"r\\rend\"");
 	is_enc("\x01",          "\"\\x01\"");
+	ok(strcmp(log_u(42u), "42") == 0, "U(42)");
+	ok(strcmp(log_i(-7), "-7") == 0, "I(-7)");
+	ok(strcmp(log_hex(0xa2u), "0xa2") == 0, "HEX(0xa2)");
+	{
+		unsigned char b[] = { 0x30, 0x82, 0x0f };
+		ok(strcmp(log_hexbuf(b, sizeof(b)), "30820f") == 0, "HEXBUF");
+	}
+	{
+		/* ring holds >=4 distinct live values in one expression */
+		const char *a = log_u(1), *b = log_u(2), *c = log_u(3), *d = log_u(4);
+		ok(strcmp(a, "1") == 0 && strcmp(b, "2") == 0 &&
+		   strcmp(c, "3") == 0 && strcmp(d, "4") == 0, "ring keeps 4 live");
+	}
 	return tap_done();
 }

--- a/v3_crypto.c
+++ b/v3_crypto.c
@@ -60,17 +60,17 @@ hmac_message(const struct snmpv3info* v3,
     unsigned md_len = 0;
 
     if (!md || maclen < 0) {
-        log_error("bad auth protocol");
+        log_error("bad auth protocol", NULL);
         errno = EINVAL;
         return -1;
     }
     if (out_size < (unsigned)maclen) {
-        log_error("bad hmac output buffer size");
+        log_error("bad hmac output buffer size", NULL);
         errno = EINVAL;
         return -1;
     }
     if (auth_param - msg + maclen >= msg_len) {
-        log_error("bad auth_param pointer");
+        log_error("bad auth_param pointer", NULL);
         errno = EINVAL;
         return -1;
     }
@@ -134,7 +134,7 @@ encrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const st
         cipher = EVP_aes_256_cfb128();
         break;
     default:
-        log_error("encrypt_in_place: unrecognized or unsupported privacy algorithm");
+        log_error("unsupported privacy algorithm", "op", "encrypt", NULL);
         return -1;
         break;
     }
@@ -164,7 +164,7 @@ encrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const st
 	// dump_buf(stderr, ciphertext, ciphertext_len);
 
     if (buf_len != ciphertext_len) {
-        log_error("encrypt_in_place: unexpectedly, ciphertext_len != plaintext_len in CFB mode");
+        log_error("ciphertext length mismatch in CFB", "op", "encrypt", NULL);
         EVP_CIPHER_CTX_free(ctx);
         free(ciphertext);
         return -1;
@@ -211,7 +211,7 @@ decrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const st
         cipher = EVP_aes_256_cfb128();
         break;
     default:
-        log_error("decrypt_in_place: unrecognized or unsupported privacy algorithm");
+        log_error("unsupported privacy algorithm", "op", "decrypt", NULL);
         return -1;
         break;
     }
@@ -241,7 +241,7 @@ decrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const st
 	// dump_buf(stderr, plaintext, plaintext_len);
 
     if (buf_len != plaintext_len) {
-        log_error("decrypt_in_place: unexpectedly, ciphertext_len != plaintext_len in CFB mode");
+        log_error("ciphertext length mismatch in CFB", "op", "decrypt", NULL);
         EVP_CIPHER_CTX_free(ctx);
         free(plaintext);
         return -1;


### PR DESCRIPTION
Converts all daemon log output to logfmt-style `key=value` lines: `time=... level=... msg="..."` plus typed fields (`peer=`, `sid=`, `error=`, ...), with the journald `<N>` priority prefix behavior preserved when supervised by systemd.

New in log.c/log.h: a logfmt value encoder, scalar field helpers, a pure line assembler (unit-tested in both plain and journald modes), and sentinel-terminated varargs emitters. All ~54 call sites converted; messages are constant, dynamic data moved into fields. Debug-level packet hex dumps replace the old raw stderr dumps, and truncated lines are guaranteed newline-terminated so records never merge.

## Test plan
- [x] `make test` — 315 tests PASS (unit + daemon integration tiers)
- [x] scan-build — "No bugs found."
- [x] TDD red/green for every new log.c unit and both review-round fixes