### PR TITLE
Audit log points: stop leaking setopt secrets, add correlation fields

### DIFF
--- a/.changes/unreleased/Changed-20260705-184023.yaml
+++ b/.changes/unreleased/Changed-20260705-184023.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Log lines carry peer, message id, and connection details
+time: 2026-07-05T18:40:23.924172+02:00

--- a/.changes/unreleased/Security-20260705-184022.yaml
+++ b/.changes/unreleased/Security-20260705-184022.yaml
@@ -1,0 +1,3 @@
+kind: Security
+body: No longer log SNMPv3 credentials when a setopt request fails
+time: 2026-07-05T18:40:22.905354+02:00

--- a/client_input.c
+++ b/client_input.c
@@ -67,11 +67,6 @@ client_input(struct socket_info *si)
 		PS.client_requests++;
 		si->PS.client_requests++;
 
-		//if (!opt_quiet) {
-		//	printf("got client input: ");
-		//	msgpack_object_print(stdout, c->input.data);
-		//	printf("\n");
-		//}
 		o = &c->input.data;
 		if (o->type != MSGPACK_OBJECT_ARRAY) {
 			error_reply(si, RT_ERROR, 0, "Request is not an array");

--- a/client_input.c
+++ b/client_input.c
@@ -98,10 +98,6 @@ client_input(struct socket_info *si)
         switch (type) {
         case RT_SETOPT:
             ok = handle_setopt_request(si, cid, o);
-            if (ok < 0) {
-                log_warn("problem handling setopt", "cid", U(cid), NULL);
-                msgpack_object_print(stderr, *o);
-            }
             break;
         case RT_GETOPT:
             ok = handle_getopt_request(si, cid, o);

--- a/client_input.c
+++ b/client_input.c
@@ -12,6 +12,7 @@ static void
 client_gone(struct socket_info *si)
 {
 	struct client_connection *c = si->udata;
+	int fd = si->fd;
 
 	PS.active_client_connections--;
 
@@ -23,7 +24,7 @@ client_gone(struct socket_info *si)
 		msgpack_unpacker_destroy(&c->unpacker);
 		free(c);
 	}
-	log_info("client disconnect", NULL);
+	log_info("client disconnect", "fd", U((unsigned)fd), NULL);
 }
 
 static void

--- a/client_listen.c
+++ b/client_listen.c
@@ -14,11 +14,14 @@ do_accept(struct socket_info *lsi)
 	struct sockaddr_in addr;
 	int fd;
 	unsigned len;
+	char peer[64];
 
 	len = sizeof(addr);
 	if ( (fd = accept(lsi->fd, (struct sockaddr *)&addr, &len)) < 0)
 		croak(1, "do_accept: accept");
-	log_info("incoming connection", "peer", inet_ntoa(addr.sin_addr), NULL);
+	snprintf(peer, sizeof(peer), "%s:%d", inet_ntoa(addr.sin_addr),
+	    ntohs(addr.sin_port));
+	log_info("incoming connection", "peer", peer, "fd", U((unsigned)fd), NULL);
 	new_client_connection(fd);
 }
 

--- a/destination.c
+++ b/destination.c
@@ -142,7 +142,6 @@ maybe_query_destination(struct destination *dest)
 	}
 	if (dest->packets_on_the_wire >= dest->max_packets_on_the_wire) {
 		PS.destination_throttles++;
-//fprintf(stderr, "%s: max_packets_on_the_wire(%d)\n", inet_ntoa(dest->ip), dest->packets_on_the_wire);
 		return;
 	}
 	if (dest->can_query_at.tv_sec) {
@@ -150,12 +149,10 @@ maybe_query_destination(struct destination *dest)
 		if (now.tv_sec < dest->can_query_at.tv_sec ||
 			(now.tv_sec == dest->can_query_at.tv_sec && now.tv_usec < dest->can_query_at.tv_usec))
 		{
-//fprintf(stderr, "%s: min_interval\n", inet_ntoa(dest->ip));
 			return;
 		}
 	}
 
-//fprintf(stderr, "%s: ok(%d)\n", inet_ntoa(dest->ip), dest->packets_on_the_wire);
 	/* Then find a client_requests_info, in a round-robin fashion,
 	 * which has anything to send.   Be careful with when to stop.
 	 */
@@ -180,7 +177,6 @@ void
 destination_timer(struct destination *dest)
 {
 	// XXX implement me
-//fprintf(stderr, "%s: min_interval timer tick (%d)\n", inet_ntoa(dest->ip), dest->packets_on_the_wire);
 	destination_stop_timing(dest);
 	maybe_query_destination(dest);
 }

--- a/event_loop.c
+++ b/event_loop.c
@@ -90,11 +90,11 @@ flush_buffers(struct socket_info *si)
 	if ( (n = writev(si->fd, io_buf, i)) < 0) {
 		switch (errno) {
 		case EPIPE:
-			log_warn("EPIPE during write", "op", "flush_buffers", NULL);
+			log_warn("EPIPE during write", "fd", U((unsigned)si->fd), "op", "flush_buffers", NULL);
 			if (si->eof_handler)	si->eof_handler(si);
 			return;
 		case ECONNRESET:
-			log_warn("ECONNRESET during write", "op", "flush_buffers", NULL);
+			log_warn("ECONNRESET during write", "fd", U((unsigned)si->fd), "op", "flush_buffers", NULL);
 			if (si->eof_handler)	si->eof_handler(si);
 			return;
 		}

--- a/request_common.c
+++ b/request_common.c
@@ -15,6 +15,8 @@ error_reply(struct socket_info *si, unsigned code, unsigned cid, char *error)
 	msgpack_packer* pk = msgpack_packer_new(buffer, msgpack_sbuffer_write);
 	int l = strlen(error);
 
+	log_debug("client request error", "cid", U(cid), "code", HEX(code),
+	    "error", error, NULL);
 	msgpack_pack_array(pk, 3);
 	msgpack_pack_unsigned_int(pk, code);
 	msgpack_pack_unsigned_int(pk, cid);

--- a/sid_info.c
+++ b/sid_info.c
@@ -291,7 +291,6 @@ sid_timer(struct sid_info *si)
 	PS.packets_on_the_wire--;
 	if (PS.packets_on_the_wire < 0)
 		PS.packets_on_the_wire = 0;
-// fprintf(stderr, "%s: sid_timer->(%d)\n", inet_ntoa(si->cri->dest->ip), si->cri->dest->packets_on_the_wire);
 	sid_stop_timing(si);
 	if (si->retries_left > 0) {
 		resend_query_with_new_sid(si);

--- a/sid_info.c
+++ b/sid_info.c
@@ -8,6 +8,16 @@
  */
 #include "sqe.h"
 
+static const char *
+dest_peer(struct destination *dest)
+{
+	static char peer[64];
+
+	snprintf(peer, sizeof(peer), "%s:%d", inet_ntoa(dest->dest_addr.sin_addr),
+	    ntohs(dest->dest_addr.sin_port));
+	return peer;
+}
+
 struct sid_info *
 new_sid_info(struct client_requests_info *cri)
 {
@@ -449,7 +459,8 @@ process_sid_info_response(struct sid_info *si, struct ber *e)
 		}
 	} else {
 		if (!TAILQ_EMPTY(&si->oids_being_queried)) {
-			log_warn("not all oids accounted for", "sid", U(si->sid), NULL);
+			log_warn("not all oids accounted for", "peer", dest_peer(cri->dest),
+			    "sid", U(si->sid), NULL);
 			all_oids_done(si, &BER_MISSING);
 		}
 	}
@@ -462,7 +473,8 @@ process_sid_info_response(struct sid_info *si, struct ber *e)
 	return 1;
 bad_snmp_packet:
 	PS.bad_snmp_responses++;
-	log_warn("bad SNMP packet, ignoring", "sid", U(si->sid), "trace", trace, NULL);
+	log_warn("bad SNMP packet, ignoring", "peer", dest_peer(cri->dest),
+	    "sid", U(si->sid), "trace", trace, NULL);
 	return 0;
 }
 

--- a/snmp.c
+++ b/snmp.c
@@ -148,7 +148,7 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 				p += snprintf(known+p, sizeof(known)-p, "%02x", siv3->engine_id[i]);
 			for (p = 0, i = 0; i < v3.engine_id_len; i++)
 				p += snprintf(received+p, sizeof(received)-p, "%02x", v3.engine_id[i]);
-			log_warn("engine-id mismatch, ignoring packet", "peer", peer,
+			log_warn("engine-id mismatch, ignoring packet", "peer", peer, "mid", U(mid),
 					"known_engine_id", known, "recv_engine_id", received, NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
@@ -156,7 +156,7 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
 		// - verify username
 		if (strcmp(siv3->username, v3.username) != 0) {
-			log_warn("username mismatch, ignoring packet", "peer", peer,
+			log_warn("username mismatch, ignoring packet", "peer", peer, "mid", U(mid),
 					"known_username", siv3->username, "username", v3.username, NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
@@ -177,8 +177,9 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 			memset(auth_param_ptr, 0, maclen); // clear original HMAC location for auth calculations
     		if (hmac_message(siv3, auth_param_ptr, maclen, e->buf, e->max_len, auth_param_ptr) < 0) {
 				memcpy(auth_param_ptr, auth_param, maclen);
-				log_warn("authentication failed", "peer", peer, "error", strerror(errno), NULL);
-				log_debug("authentication failed", "peer", peer,
+				log_warn("authentication failed", "peer", peer, "mid", U(mid),
+						"error", strerror(errno), NULL);
+				log_debug("authentication failed", "peer", peer, "mid", U(mid),
 						"packet", HEXBUF(e->buf, e->max_len), NULL);
 				trace = NULL;
 				goto bad_snmp_packet;
@@ -188,8 +189,8 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
 				snprintf(auth_calc, sizeof(auth_calc), "%s", HEXBUF(auth_param_ptr, maclen));
 				memcpy(auth_param_ptr, auth_param, maclen);
-				log_warn("authentication failed", "peer", peer, NULL);
-				log_debug("authentication failed", "peer", peer,
+				log_warn("authentication failed", "peer", peer, "mid", U(mid), NULL);
+				log_debug("authentication failed", "peer", peer, "mid", U(mid),
 						"auth_calc", auth_calc,
 						"packet", HEXBUF(e->buf, e->max_len), NULL);
 				trace = NULL;
@@ -208,7 +209,7 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
         	if (t != AT_STRING) goto bad_snmp_packet;
 			// - decrypt
 			if (decrypt_in_place(e->b, l, priv_param, siv3) < 0) {
-				log_warn("cannot decrypt, ignoring packet", "peer", peer, NULL);
+				log_warn("cannot decrypt, ignoring packet", "peer", peer, "mid", U(mid), NULL);
 				trace = NULL;
 				goto bad_snmp_packet;
 			}
@@ -228,7 +229,7 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 			for (p = 0, i = 0; i < l; i++)
 				p += snprintf(context+p, sizeof(context)-p, "%02x", context_engine_id[i]);
 			log_warn("authoritative/context engine-id mismatch, ignoring packet", "peer", peer,
-					"auth_engine_id", authoritative, "context_engine_id", context, NULL);
+					"mid", U(mid), "auth_engine_id", authoritative, "context_engine_id", context, NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
         }
@@ -246,7 +247,8 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 		}
 		t = e->b[0];
 		if (t != PDU_REPORT && t != PDU_GET_RESPONSE) {
-			log_warn("unsupported PDU type, ignoring packet", "peer", peer, "pdu_type", HEX(t), NULL);
+			log_warn("unsupported PDU type, ignoring packet", "peer", peer, "mid", U(mid),
+					"pdu_type", HEX(t), NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
 		}
@@ -270,11 +272,13 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
 			CHECK("error-status", decode_integer(e, -1, &error_status));
 			if (error_status != 0) {
-				log_warn("non-zero error-status", "peer", peer, "error_status", I(error_status), NULL);
+				log_warn("non-zero error-status", "peer", peer, "mid", U(mid),
+						"error_status", I(error_status), NULL);
 			}
 			CHECK("error-index", decode_integer(e, -1, &error_index));
 			if (error_index != 0) {
-				log_warn("non-zero error-index", "peer", peer, "error_index", I(error_index), NULL);
+				log_warn("non-zero error-index", "peer", peer, "mid", U(mid),
+						"error_index", I(error_index), NULL);
 			}
 
 			// - analyze varbinds and report
@@ -291,12 +295,12 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 					resend_query_with_new_sid(si);
 					return;
 				} else if (oid_compare(&oid, &usmStatsWrongDigests) == 0) {
-					log_warn("report: bad digest, ignoring packet", "peer", peer, NULL);
+					log_warn("report: bad digest, ignoring packet", "peer", peer, "mid", U(mid), NULL);
 					trace = NULL;
 					goto bad_snmp_packet;
 				} else {
-					log_warn("report", "peer", peer, "oid", oid2str(oid), NULL);
-					log_debug("report", "peer", peer,
+					log_warn("report", "peer", peer, "mid", U(mid), "oid", oid2str(oid), NULL);
+					log_debug("report", "peer", peer, "mid", U(mid),
 							"value", HEXBUF(val.buf, (size_t)val.len), NULL);
 					trace = NULL;
 					goto bad_snmp_packet;

--- a/snmp.c
+++ b/snmp.c
@@ -285,7 +285,6 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 				CHECK("value", decode_any(e, &val));
 
 				if (oid_compare(&oid, &usmStatsNotInTimeWindows) == 0) {
-					// fprintf(stderr, "%s: report: our request not in time window, need to resend request\n", log);
 					sid_stop_timing(si);
 					si->retries_left++;  // a hack since resend() decrements this
 					// XXX resend() increments snmp_retries counter(s), which is misleading in this case
@@ -391,7 +390,6 @@ void snmp_send(struct destination *dest, struct ber *packet)
 
 	dest->packets_on_the_wire++;
 	PS.packets_on_the_wire++;
-//fprintf(stderr, "%s: snmp_send->(%d)\n", inet_ntoa(dest->ip), dest->packets_on_the_wire);
 	n = sendto(snmp->fd, packet->buf, packet->len, 0,
 			   (struct sockaddr *)&dest->dest_addr,
 			   sizeof(dest->dest_addr));
@@ -404,8 +402,6 @@ void snmp_send(struct destination *dest, struct ber *packet)
 	}
 	if (n != packet->len)
 		croakx(1, "snmp_send: short send");
-//fprintf(stderr, "UDP datagram of %d bytes sent to %s:%d\n", packet->len, inet_ntoa(dest->dest_addr.sin_addr), ntohs(dest->dest_addr.sin_port));
-//dump_buf(stderr, packet->buf, packet->len);
 
 	dest->octets_sent += packet->len;
 	PS.octets_sent += packet->len;

--- a/t/lib/SQE/FakeAgent.pm
+++ b/t/lib/SQE/FakeAgent.pm
@@ -24,6 +24,7 @@ sub spawn {
 		drop_first => $opt{drop_first} // 0,
 		drop_all   => $opt{drop_all} // 0,
 		repeat_oid => $opt{repeat_oid},
+		omit_oid   => $opt{omit_oid},
 		malformed  => $opt{malformed} // '',
 		delay_ms   => $opt{delay_ms} // 0,
 	}, $class;
@@ -274,6 +275,9 @@ sub _handle {
 	} else {
 		die "unsupported pdu $pdu_tag\n";
 	}
+
+	@out = grep { $_->[0] ne $self->{omit_oid} } @out
+		if defined $self->{omit_oid};
 
 	my $vbl_out = join '', map {
 		_tlv(0x30, _tlv(0x06, _enc_oid_content($_->[0])) . _enc_value($_->[1], $_->[2]))

--- a/t/logging.t
+++ b/t/logging.t
@@ -7,6 +7,7 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test2::V0;
 use File::Temp ();
+use Time::HiRes ();
 use SQE::Test qw(spawn_daemon request_match
 	RT_SETOPT RT_GET RT_INFO RT_REPLY RT_ERROR);
 use SQE::FakeAgent;
@@ -24,12 +25,17 @@ subtest 'default level: info, plain format' => sub {
 	my $log = File::Temp->new;
 	my $d = spawn_daemon(args => [], stderr_file => "$log");
 	$d->request([RT_INFO, 1]);
+	$d->{conn}->close;
+	Time::HiRes::sleep(0.1);
 	$d->stop;
 	my $text = slurp("$log");
 	like($text, qr/^time=$TS level=info msg="event loop started" op=(?:epoll|kqueue)$/m,
 		'startup line at info with timestamp');
-	like($text, qr/^time=$TS level=info msg="incoming connection"/m,
-		'connection notice at info');
+	like($text, qr/^time=$TS level=info msg="incoming connection" peer=127\.0\.0\.1:\d+ fd=(\d+)$/m,
+		'connection notice carries peer:port and fd');
+	my ($fd) = $text =~ /msg="incoming connection" peer=[\d.]+:\d+ fd=(\d+)/;
+	like($text, qr/^time=$TS level=info msg="client disconnect" fd=\Q$fd\E$/m,
+		'disconnect carries the matching fd');
 	unlike($text, qr/level=debug/, 'no debug lines by default');
 };
 

--- a/t/logging.t
+++ b/t/logging.t
@@ -9,6 +9,7 @@ use Test2::V0;
 use File::Temp ();
 use SQE::Test qw(spawn_daemon request_match
 	RT_SETOPT RT_GET RT_INFO RT_REPLY RT_ERROR);
+use SQE::FakeAgent;
 
 my $TS = qr/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[-+]\d{4}/;
 
@@ -99,6 +100,27 @@ subtest 'client request errors logged at debug' => sub {
 	like($text,
 		qr/^time=$TS level=debug msg="client request error" cid=8 code=0x24 error="bad request length"$/m,
 		'get failure reason at debug (funnel covers all request types)');
+};
+
+subtest 'sid_info warns carry peer' => sub {
+	my $agent = SQE::FakeAgent->spawn(
+		tree     => [['1.3.6.1.2.1.1.5.0', str => 'fake']],
+		omit_oid => '1.3.6.1.2.1.1.6.0');
+	my $aport = $agent->port;
+	my $log = File::Temp->new;
+	my $d = spawn_daemon(args => [], stderr_file => "$log");
+	request_match($d, "setopt v2c to fake agent",
+		[RT_SETOPT, 1, "127.0.0.1", $aport, {version => 2}],
+		[RT_SETOPT|RT_REPLY, 1, T()]);
+	request_match($d, "get with an omitted oid",
+		[RT_GET, 2, "127.0.0.1", $aport,
+			["1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.6.0"]],
+		[RT_GET|RT_REPLY, 2, T()]);
+	$d->stop;
+	$agent->stop;
+	like(slurp("$log"),
+		qr/^time=$TS level=warn msg="not all oids accounted for" peer=127\.0\.0\.1:$aport sid=\d+$/m,
+		'warn carries peer and sid');
 };
 
 done_testing;

--- a/t/logging.t
+++ b/t/logging.t
@@ -7,7 +7,8 @@ use FindBin;
 use lib "$FindBin::Bin/lib";
 use Test2::V0;
 use File::Temp ();
-use SQE::Test qw(spawn_daemon RT_INFO RT_REPLY);
+use SQE::Test qw(spawn_daemon request_match
+	RT_SETOPT RT_GET RT_INFO RT_REPLY RT_ERROR);
 
 my $TS = qr/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[-+]\d{4}/;
 
@@ -60,6 +61,44 @@ subtest 'journald mode: <N> prefixes, no timestamps' => sub {
 	like($text, qr/^<6>msg="event loop started" op=(?:epoll|kqueue)$/m,
 		'info line carries <6> prefix');
 	unlike($text, qr/^$TS/m, 'no timestamps in journald mode');
+};
+
+subtest 'setopt failure leaks no request content' => sub {
+	my $log = File::Temp->new;
+	my $d = spawn_daemon(args => [], stderr_file => "$log");
+	request_match($d, "setopt with secrets fails on bad key",
+		[RT_SETOPT, 42, "127.0.0.1", 161, {
+			authpassword => "s3cr3tauthpw",
+			privpassword => "s3cr3tprivpw",
+			meow         => 1,
+		}],
+		[RT_SETOPT|RT_ERROR, 42, qr/bad option key/]);
+	$d->stop;
+	my $text = slurp("$log");
+	unlike($text, qr/s3cr3tauthpw/, 'auth password not in the log');
+	unlike($text, qr/s3cr3tprivpw/, 'priv password not in the log');
+	unlike($text, qr/problem handling setopt/, 'setopt-specific warn is gone');
+	my @bad = grep { length && !/^time=$TS level=\w+ msg=/ } split /\n/, $text;
+	is(\@bad, [], 'every log line is a single logfmt record');
+};
+
+subtest 'client request errors logged at debug' => sub {
+	my $log = File::Temp->new;
+	my $d = spawn_daemon(args => ['-d'], stderr_file => "$log");
+	request_match($d, "bad setopt",
+		[RT_SETOPT, 7, "127.0.0.1", 161, {meow => 1}],
+		[RT_SETOPT|RT_ERROR, 7, qr/bad option key/]);
+	request_match($d, "bad get",
+		[RT_GET, 8, "127.0.0.1"],
+		[RT_GET|RT_ERROR, 8, qr/bad request length/]);
+	$d->stop;
+	my $text = slurp("$log");
+	like($text,
+		qr/^time=$TS level=debug msg="client request error" cid=7 code=0x21 error="bad option key"$/m,
+		'setopt failure reason at debug');
+	like($text,
+		qr/^time=$TS level=debug msg="client request error" cid=8 code=0x24 error="bad request length"$/m,
+		'get failure reason at debug (funnel covers all request types)');
 };
 
 done_testing;

--- a/v3_crypto.c
+++ b/v3_crypto.c
@@ -158,11 +158,6 @@ encrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const st
         goto fail;
     ciphertext_len += len;
 
-    // fprintf(stderr, "encrypt_in_place: plaintext (%d bytes):\n", buf_len);
-	// dump_buf(stderr, buf, buf_len);
-    // fprintf(stderr, "encrypt_in_place: ciphertext (%d bytes):\n", ciphertext_len);
-	// dump_buf(stderr, ciphertext, ciphertext_len);
-
     if (buf_len != ciphertext_len) {
         log_error("ciphertext length mismatch in CFB", "op", "encrypt", NULL);
         EVP_CIPHER_CTX_free(ctx);
@@ -234,11 +229,6 @@ decrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const st
     if (1 != EVP_DecryptFinal_ex(ctx, plaintext + len, &len))
         goto fail;
     plaintext_len += len;
-
-    // fprintf(stderr, "decrypt_in_place: ciphertext (%d bytes):\n", buf_len);
-	// dump_buf(stderr, buf, buf_len);
-    // fprintf(stderr, "decrypt_in_place: plaintext (%d bytes):\n", plaintext_len);
-	// dump_buf(stderr, plaintext, plaintext_len);
 
     if (buf_len != plaintext_len) {
         log_error("ciphertext length mismatch in CFB", "op", "decrypt", NULL);


### PR DESCRIPTION
Fixes the last raw stderr dump left after the logfmt conversion and tightens existing log points.

- A failed setopt request no longer dumps the raw request object (which
  includes SNMPv3 auth/priv passwords) into the log. Instead, every failed
  client request is logged at debug level as a single logfmt record with
  the same reason string the client receives: `msg="client request error"
  cid=... code=... error="..."`.
- Deleted all commented-out fprintf/dump corpses (destination.c, snmp.c,
  sid_info.c, v3_crypto.c, client_input.c).
- Correlation fields added: `peer` (ip:port) on sid_info SNMP warnings,
  `mid` on the SNMPv3 packet warnings in snmp.c, client port and `fd` on
  connect/disconnect notices and on client write-error warnings.
- New SQE::FakeAgent knob `omit_oid` drops one varbind from otherwise
  well-formed responses, making the "not all oids accounted for" path
  deterministically testable.

Test plan:
- [x] new t/logging.t subtests: secrets absent from log on setopt failure,
      one-record-per-line integrity, debug-level error funnel, peer on
      sid_info warns, fd correlation on connect/disconnect
- [x] full `make test` green (318/318)
- [x] scan-build: No bugs found.