### PR TITLE
refactor: single peer_str() helper for ip:port formatting

### DIFF
--- a/client_listen.c
+++ b/client_listen.c
@@ -14,14 +14,11 @@ do_accept(struct socket_info *lsi)
 	struct sockaddr_in addr;
 	int fd;
 	unsigned len;
-	char peer[64];
 
 	len = sizeof(addr);
 	if ( (fd = accept(lsi->fd, (struct sockaddr *)&addr, &len)) < 0)
 		croak(1, "do_accept: accept");
-	snprintf(peer, sizeof(peer), "%s:%d", inet_ntoa(addr.sin_addr),
-	    ntohs(addr.sin_port));
-	log_info("incoming connection", "peer", peer, "fd", U((unsigned)fd), NULL);
+	log_info("incoming connection", "peer", peer_str(&addr), "fd", U((unsigned)fd), NULL);
 	new_client_connection(fd);
 }
 

--- a/sid_info.c
+++ b/sid_info.c
@@ -8,16 +8,6 @@
  */
 #include "sqe.h"
 
-static const char *
-dest_peer(struct destination *dest)
-{
-	static char peer[64];
-
-	snprintf(peer, sizeof(peer), "%s:%d", inet_ntoa(dest->dest_addr.sin_addr),
-	    ntohs(dest->dest_addr.sin_port));
-	return peer;
-}
-
 struct sid_info *
 new_sid_info(struct client_requests_info *cri)
 {
@@ -459,7 +449,7 @@ process_sid_info_response(struct sid_info *si, struct ber *e)
 		}
 	} else {
 		if (!TAILQ_EMPTY(&si->oids_being_queried)) {
-			log_warn("not all oids accounted for", "peer", dest_peer(cri->dest),
+			log_warn("not all oids accounted for", "peer", peer_str(&cri->dest->dest_addr),
 			    "sid", U(si->sid), NULL);
 			all_oids_done(si, &BER_MISSING);
 		}
@@ -473,7 +463,7 @@ process_sid_info_response(struct sid_info *si, struct ber *e)
 	return 1;
 bad_snmp_packet:
 	PS.bad_snmp_responses++;
-	log_warn("bad SNMP packet, ignoring", "peer", dest_peer(cri->dest),
+	log_warn("bad SNMP packet, ignoring", "peer", peer_str(&cri->dest->dest_addr),
 	    "sid", U(si->sid), "trace", trace, NULL);
 	return 0;
 }

--- a/snmp.c
+++ b/snmp.c
@@ -23,10 +23,7 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 	char *trace;
 	struct destination *dest;
 	struct sid_info *si;
-	char peer[64];
-
-	snprintf(peer, sizeof(peer), "%s:%d", inet_ntoa(from->sin_addr),
-	    ntohs(from->sin_port));
+	const char *peer = peer_str(from);
 
 	PS.octets_received += n;
 	dest = find_destination(&from->sin_addr, ntohs(from->sin_port));

--- a/sqe.h
+++ b/sqe.h
@@ -544,6 +544,7 @@ extern unsigned next_sid(void);
 extern unsigned next_sid_from(unsigned cur);
 extern void dump_buf(FILE *f, void *buf, int len);
 extern char *oid2str(struct ber o);
+extern const char *peer_str(struct sockaddr_in *sa);
 extern char *timestring(void);
 
 /* destination.c */

--- a/util.c
+++ b/util.c
@@ -205,6 +205,16 @@ oid2str(struct ber o)
 	return oid2str_buf;
 }
 
+static char peer_str_buf[64];
+
+const char *
+peer_str(struct sockaddr_in *sa)
+{
+	snprintf(peer_str_buf, sizeof(peer_str_buf), "%s:%d",
+	    inet_ntoa(sa->sin_addr), ntohs(sa->sin_port));
+	return peer_str_buf;
+}
+
 static char timestring_buf[256];
 
 char *


### PR DESCRIPTION
Collapse three open-coded `"%s:%d"` formatters of `inet_ntoa(sin_addr)` +
`ntohs(sin_port)` into one `peer_str(struct sockaddr_in *)` helper in util.c,
alongside the other small formatters (oid2str, timestring).

- **snmp.c** — the inline `char peer[64]` in `snmp_process_datagram` becomes
  `const char *peer = peer_str(from)`, formatted once at the top as before;
  all downstream log sites keep using `peer`.
- **client_listen.c** — `do_accept` drops its local buffer and passes `&addr`.
- **sid_info.c** — the `dest_peer()` helper is removed; both callers pass
  `&cri->dest->dest_addr` directly.

Behaviour-preserving: the emitted `peer=ip:port` shape is unchanged and is
pinned by the existing t/logging.t assertions at all three sites.

`sid_info.c:495`'s `CRI(%s:%d->%d)` format is intentionally left alone — it's
a different shape from different fields.

Test plan:
- [x] `make clean && make` — clean, `-Werror`
- [x] `make test` — 318 tests pass (t/logging.t green)
- [x] `scan-build make` — No bugs found