### PR TITLE
feat: log listening config at startup and the shutdown signal

### DIFF
--- a/.changes/unreleased/Added-20260705-213714.yaml
+++ b/.changes/unreleased/Added-20260705-213714.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Log listening config at startup and the signal that triggered shutdown
+time: 2026-07-05T21:37:14.563136+02:00

--- a/event_loop.c
+++ b/event_loop.c
@@ -334,6 +334,16 @@ pending_client_output(void)
 	return 0;
 }
 
+static const char *
+sig_name(int sig)
+{
+	switch (sig) {
+	case SIGTERM: return "SIGTERM";
+	case SIGINT:  return "SIGINT";
+	default:      return U((unsigned)sig);
+	}
+}
+
 static void
 begin_shutdown(void)
 {
@@ -343,7 +353,7 @@ begin_shutdown(void)
 	shutdown_active = 1;
 	gettimeofday(&shutdown_started, NULL);
 	notify("STOPPING=1");
-	log_info("shutting down", NULL);
+	log_info("shutting down", "signal", sig_name(stop_signal), NULL);
 	if (listener_si) {
 		delete_socket_info(listener_si);
 		listener_si = NULL;

--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@
 static void
 handle_stop_signal(int sig)
 {
-	(void)sig;
+	stop_signal = sig;
 	stop_requested = 1;
 }
 

--- a/main.c
+++ b/main.c
@@ -98,6 +98,13 @@ main(int argc, char **argv)
 
 	create_snmp_socket();
 	create_listening_socket(bindaddr, port);
+	log_info("listening",
+	    "client_addr", inet_ntoa(bindaddr),
+	    "client_port", U((unsigned)port),
+	    "snmp_rcvbuf", U((unsigned)PS.udp_receive_buffer_size),
+	    "snmp_sndbuf", U((unsigned)PS.udp_send_buffer_size),
+	    "max_packets_on_the_wire", U((unsigned)PS.max_packets_on_the_wire),
+	    "version", SQE_VERSION, NULL);
 	notify("READY=1");
 	event_loop();
 

--- a/opts.c
+++ b/opts.c
@@ -10,3 +10,4 @@
 
 enum log_level opt_log_level = LL_INFO;
 volatile sig_atomic_t stop_requested = 0;
+volatile sig_atomic_t stop_signal = 0;

--- a/sqe.h
+++ b/sqe.h
@@ -186,6 +186,7 @@ struct program_stats
 extern struct timeval prog_start;
 extern struct program_stats PS;
 extern volatile sig_atomic_t stop_requested;
+extern volatile sig_atomic_t stop_signal;
 
 struct ber
 {

--- a/t/logging.t
+++ b/t/logging.t
@@ -39,6 +39,17 @@ subtest 'default level: info, plain format' => sub {
 	unlike($text, qr/level=debug/, 'no debug lines by default');
 };
 
+subtest 'startup config summary' => sub {
+	my $log = File::Temp->new;
+	my $d = spawn_daemon(args => [], stderr_file => "$log");
+	my $port = $d->port;
+	$d->stop;
+	my $text = slurp("$log");
+	like($text,
+		qr/^time=$TS level=info msg=listening client_addr=127\.0\.0\.1 client_port=\Q$port\E snmp_rcvbuf=\d+ snmp_sndbuf=\d+ max_packets_on_the_wire=1000000 version=\S+$/m,
+		'startup line reports bind addr, port, negotiated buffers, limit, version');
+};
+
 subtest '-q: warnings and errors only' => sub {
 	my $log = File::Temp->new;
 	my $d = spawn_daemon(args => ['-q'], stderr_file => "$log");

--- a/t/logging.t
+++ b/t/logging.t
@@ -140,4 +140,13 @@ subtest 'sid_info warns carry peer' => sub {
 		'warn carries peer and sid');
 };
 
+subtest 'shutdown reason' => sub {
+	my $log = File::Temp->new;
+	my $d = spawn_daemon(args => [], stderr_file => "$log");
+	$d->stop;   # sends SIGTERM (kill 15) and reaps
+	like(slurp("$log"),
+		qr/^time=$TS level=info msg="shutting down" signal=SIGTERM$/m,
+		'shutdown line names the signal that triggered it');
+};
+
 done_testing;


### PR DESCRIPTION
## What

Adds two operator-facing log points that production deployments could not
observe before:

- **Startup config summary** — one `msg=listening` info line emitted once both
  sockets are up, reporting the client bind address and port, the *negotiated*
  SNMP socket receive/send buffer sizes, the max-packets-on-the-wire limit, and
  the version. The buffer sizes are negotiated down from a large request until
  the kernel accepts them, so the achieved values were previously invisible.
- **Shutdown reason** — the signal that triggered shutdown is captured and shown
  on the existing `shutting down` line (e.g. `signal=SIGTERM`), so a restart's
  cause is recorded in the log.

Both are info level (suppressed under `-q`), logfmt, single-line.

## Why

An operator restarting or supervising the daemon had no log record of the
running configuration or of what caused a shutdown. These two lines close that
gap without adding per-packet volume.

## Out of scope

Deferred to their own backlog items and intentionally not touched here:
periodic stats summaries (already client-queryable), per-packet send-buffer
overflow logging (belongs with log throttling), and the `accept()`-on-fd-
exhaustion crash (an availability fix, not a log point).

## Test plan

- [x] New `t/logging.t` subtests drive the real daemon: assert the `listening`
      line carries the bound port, negotiated buffers, limit, and version; and
      that the `shutting down` line carries `signal=SIGTERM`.
- [x] Full suite green: 320/320 (`make test`).
- [x] scan-build clean: `No bugs found`.
- [x] Clean `-Werror` rebuild.