### PR TITLE
feat: coalesce repeated log messages to prevent log floods

### DIFF
--- a/.changes/unreleased/Added-20260708-115006.yaml
+++ b/.changes/unreleased/Added-20260708-115006.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Coalesce repeated per-agent and per-connection log messages to prevent log floods.
+time: 2026-07-08T11:50:06.078792+02:00

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ t/test_msgpack
 t/test_v3
 t/test_sid_info
 t/test_log
+t/test_throttle
 t/*.dSYM/
 *.o
 .*.swp

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OPTIMIZE=	-O3 -g
 INCPATH=	-I. -I/usr/local/include -I/opt/local/include -I/opt/homebrew/include
 LIBPATH=	-L/usr/local/lib -L/opt/local/lib -L/opt/homebrew/lib
 CFLAGS=	-Wall -Wno-unused-function -Wno-deprecated-declarations -Werror $(OPTIMIZE) $(INCPATH)
-TESTBIN=	t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log
+TESTBIN=	t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log t/test_throttle
 
 PREFIX?=	/usr/local
 BINDIR?=	$(PREFIX)/bin
@@ -29,7 +29,7 @@ STDOBJ=event_loop.o carp.o client_input.o client_listen.o opts.o util.o destinat
 STDLINK=$(STDOBJ) $(LIBPATH) $(LIBS)
 
 clean:
-	rm -f *.o snmp-query-engine t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log *.core core
+	rm -f *.o snmp-query-engine t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log t/test_throttle *.core core
 	rm -rf t/*.dSYM *.dSYM
 
 install: snmp-query-engine
@@ -118,6 +118,9 @@ notify.o: notify.c sqe.h
 
 t/test_log: t/test_log.c t/tap.h $(STDOBJ)
 	$(CC) $(CFLAGS) -o t/test_log t/test_log.c $(STDLINK)
+
+t/test_throttle: t/test_throttle.c t/tap.h $(STDOBJ)
+	$(CC) $(CFLAGS) -o t/test_throttle t/test_throttle.c $(STDLINK)
 
 t/test_ber: t/test_ber.c t/tap.h $(STDOBJ)
 	$(CC) $(CFLAGS) -o t/test_ber t/test_ber.c $(STDLINK)

--- a/client_input.c
+++ b/client_input.c
@@ -24,7 +24,8 @@ client_gone(struct socket_info *si)
 		msgpack_unpacker_destroy(&c->unpacker);
 		free(c);
 	}
-	log_info("client disconnect", "fd", U((unsigned)fd), NULL);
+	if (log_throttle_allow_standalone(LTC_CLIENT_DISCONNECT))
+		log_info("client disconnect", "fd", U((unsigned)fd), NULL);
 }
 
 static void

--- a/client_listen.c
+++ b/client_listen.c
@@ -18,7 +18,8 @@ do_accept(struct socket_info *lsi)
 	len = sizeof(addr);
 	if ( (fd = accept(lsi->fd, (struct sockaddr *)&addr, &len)) < 0)
 		croak(1, "do_accept: accept");
-	log_info("incoming connection", "peer", peer_str(&addr), "fd", U((unsigned)fd), NULL);
+	if (log_throttle_allow_standalone(LTC_INCOMING_CONNECTION))
+		log_info("incoming connection", "peer", peer_str(&addr), "fd", U((unsigned)fd), NULL);
 	new_client_connection(fd);
 }
 

--- a/destination.c
+++ b/destination.c
@@ -58,6 +58,51 @@ struct destination *find_destination(struct in_addr *ip, unsigned port)
 	return *dest_slot;
 }
 
+int
+destination_log_allow(struct destination *dest, enum log_throttle_cat cat)
+{
+	struct timeval now;
+
+	if (!dest->throttle) {
+		dest->throttle = calloc(LTC_PERDEST_COUNT, sizeof(*dest->throttle));
+		if (!dest->throttle)
+			return 1;	/* OOM: prefer logging to silence */
+	}
+	gettimeofday(&now, NULL);
+	return log_throttle_allow(&dest->throttle[cat], &now);
+}
+
+void
+flush_destination_log_rollups(const struct timeval *now)
+{
+	struct destination **dest_slot;
+	void **ip_slot;
+	Word_t ip, port;
+	enum log_throttle_cat cat;
+
+	ip = 0;
+	JLF(ip_slot, by_ip, ip);
+	while (ip_slot) {
+		port = 0;
+		JLF(dest_slot, *ip_slot, port);
+		while (dest_slot) {
+			struct destination *d = *dest_slot;
+			if (d->throttle) {
+				struct log_field ctx[1];
+				ctx[0].k = "peer";
+				ctx[0].v = peer_str(&d->dest_addr);
+				for (cat = 0; cat < LTC_PERDEST_COUNT; cat++) {
+					unsigned n = log_throttle_flush_due(&d->throttle[cat], now);
+					if (n)
+						log_throttle_rollup(cat, n, ctx, 1);
+				}
+			}
+			JLN(dest_slot, *ip_slot, port);
+		}
+		JLN(ip_slot, by_ip, ip);
+	}
+}
+
 void
 flush_ignored_destination(struct destination *dest)
 {

--- a/log.c
+++ b/log.c
@@ -227,3 +227,80 @@ log_throttle_flush_due(struct log_throttle *t, const struct timeval *now)
 	t->suppressed = 0;
 	return n;
 }
+
+static const struct {
+	const char *msg;
+	enum log_level lvl;
+} log_throttle_cat_tab[LTC_COUNT] = {
+	[LTC_LATE_REPLY]              = { "late reply, ignoring packet", LL_INFO },
+	[LTC_NO_V3_INFO]              = { "no v3 info for reply, ignoring packet", LL_WARN },
+	[LTC_ENGINE_ID_MISMATCH]      = { "engine-id mismatch, ignoring packet", LL_WARN },
+	[LTC_USERNAME_MISMATCH]       = { "username mismatch, ignoring packet", LL_WARN },
+	[LTC_AUTH_FAILED]             = { "authentication failed", LL_WARN },
+	[LTC_CANNOT_DECRYPT]          = { "cannot decrypt, ignoring packet", LL_WARN },
+	[LTC_AUTHCTX_ENGINE_MISMATCH] = { "authoritative/context engine-id mismatch, ignoring packet", LL_WARN },
+	[LTC_UNSUPPORTED_PDU]         = { "unsupported PDU type, ignoring packet", LL_WARN },
+	[LTC_MSGID_MISMATCH]          = { "message-id does not match request-id", LL_WARN },
+	[LTC_ERROR_STATUS]            = { "non-zero error-status", LL_WARN },
+	[LTC_ERROR_INDEX]             = { "non-zero error-index", LL_WARN },
+	[LTC_REPORT_BAD_DIGEST]       = { "report: bad digest, ignoring packet", LL_WARN },
+	[LTC_REPORT]                  = { "report", LL_WARN },
+	[LTC_BAD_PACKET]              = { "bad SNMP packet, ignoring", LL_WARN },
+	[LTC_OIDS_UNACCOUNTED]        = { "not all oids accounted for", LL_WARN },
+	[LTC_UNKNOWN_DESTINATION]     = { "destination not known, ignoring packet", LL_WARN },
+	[LTC_SEND_BUFFER_OVERFLOW]    = { "udp send buffer overflow, dropping datagram", LL_WARN },
+	[LTC_INCOMING_CONNECTION]     = { "incoming connection", LL_INFO },
+	[LTC_CLIENT_DISCONNECT]       = { "client disconnect", LL_INFO },
+};
+
+const char *
+log_throttle_cat_message(int cat)
+{
+	if (cat < 0 || cat >= LTC_COUNT)
+		return NULL;
+	return log_throttle_cat_tab[cat].msg;
+}
+
+void
+log_throttle_rollup(enum log_throttle_cat cat, unsigned suppressed,
+    const struct log_field *ctx, size_t nctx)
+{
+	struct log_field f[LOG_MAXFIELDS];
+	size_t n = 0, i;
+	enum log_level lvl = log_throttle_cat_tab[cat].lvl;
+	char line[LOG_LINESZ];
+
+	if (!log_wants(lvl))
+		return;
+	for (i = 0; i < nctx && n < LOG_MAXFIELDS - 2; i++)
+		f[n++] = ctx[i];
+	f[n].k = "repeated";   f[n].v = log_u(suppressed);                n++;
+	f[n].k = "interval_s"; f[n].v = log_u(LOG_THROTTLE_WINDOW_SEC);   n++;
+	log_format(line, sizeof(line), lvl, journal_mode, timestring(),
+	    log_throttle_cat_tab[cat].msg, f, n);
+	fputs(line, stderr);
+}
+
+static struct log_throttle standalone_throttle[LTC_COUNT - LTC_PERDEST_COUNT];
+
+int
+log_throttle_allow_standalone(enum log_throttle_cat cat)
+{
+	struct timeval now;
+
+	gettimeofday(&now, NULL);
+	return log_throttle_allow(&standalone_throttle[cat - LTC_PERDEST_COUNT], &now);
+}
+
+void
+log_throttle_flush_standalone(const struct timeval *now)
+{
+	enum log_throttle_cat cat;
+
+	for (cat = LTC_PERDEST_COUNT; cat < LTC_COUNT; cat++) {
+		unsigned n = log_throttle_flush_due(
+		    &standalone_throttle[cat - LTC_PERDEST_COUNT], now);
+		if (n)
+			log_throttle_rollup(cat, n, NULL, 0);
+	}
+}

--- a/log.c
+++ b/log.c
@@ -200,3 +200,30 @@ log_hexbuf(const void *buf, size_t len)
 	hexbuf_buf[2 * n] = '\0';
 	return hexbuf_buf;
 }
+
+int
+log_throttle_allow(struct log_throttle *t, const struct timeval *now)
+{
+	if (t->window_start.tv_sec == 0) {
+		t->window_start = *now;
+		t->suppressed = 0;
+		return 1;
+	}
+	t->suppressed++;
+	return 0;
+}
+
+unsigned
+log_throttle_flush_due(struct log_throttle *t, const struct timeval *now)
+{
+	unsigned n;
+
+	if (t->window_start.tv_sec == 0)
+		return 0;   /* idle */
+	if (now->tv_sec - t->window_start.tv_sec < LOG_THROTTLE_WINDOW_SEC)
+		return 0;   /* window still open */
+	n = t->suppressed;
+	t->window_start.tv_sec = 0;
+	t->suppressed = 0;
+	return n;
+}

--- a/log.h
+++ b/log.h
@@ -25,10 +25,42 @@ struct log_throttle {
 int log_throttle_allow(struct log_throttle *t, const struct timeval *now);
 unsigned log_throttle_flush_due(struct log_throttle *t, const struct timeval *now);
 
+enum log_throttle_cat {
+	/* per-destination categories (index into dest->throttle) */
+	LTC_LATE_REPLY = 0,
+	LTC_NO_V3_INFO,
+	LTC_ENGINE_ID_MISMATCH,
+	LTC_USERNAME_MISMATCH,
+	LTC_AUTH_FAILED,
+	LTC_CANNOT_DECRYPT,
+	LTC_AUTHCTX_ENGINE_MISMATCH,
+	LTC_UNSUPPORTED_PDU,
+	LTC_MSGID_MISMATCH,
+	LTC_ERROR_STATUS,
+	LTC_ERROR_INDEX,
+	LTC_REPORT_BAD_DIGEST,
+	LTC_REPORT,
+	LTC_BAD_PACKET,
+	LTC_OIDS_UNACCOUNTED,
+	LTC_PERDEST_COUNT,	/* == number of per-destination categories */
+	/* standalone categories (index into log.c static array as cat - LTC_PERDEST_COUNT) */
+	LTC_UNKNOWN_DESTINATION = LTC_PERDEST_COUNT,
+	LTC_SEND_BUFFER_OVERFLOW,
+	LTC_INCOMING_CONNECTION,
+	LTC_CLIENT_DISCONNECT,
+	LTC_COUNT
+};
+
+const char *log_throttle_cat_message(int cat);
+int log_throttle_allow_standalone(enum log_throttle_cat cat);
+void log_throttle_flush_standalone(const struct timeval *now);
+
 struct log_field { const char *k, *v; };
 int log_format(char *out, size_t outsz, enum log_level lvl, int journal_mode,
     const char *stamp, const char *msg,
     const struct log_field *fields, size_t nfields);
+void log_throttle_rollup(enum log_throttle_cat cat, unsigned suppressed,
+    const struct log_field *ctx, size_t nctx);
 
 void log_error(const char *msg, ...) __attribute__((sentinel));
 void log_warn (const char *msg, ...) __attribute__((sentinel));

--- a/log.h
+++ b/log.h
@@ -5,6 +5,7 @@
 
 #include <stdarg.h>
 #include <stddef.h>
+#include <sys/time.h>
 
 enum log_level { LL_ERROR, LL_WARN, LL_INFO, LL_DEBUG };
 
@@ -13,6 +14,16 @@ extern enum log_level opt_log_level;
 void log_setup(void);
 size_t log_enc(char *out, size_t outsz, const char *val);
 int log_wants(enum log_level lvl);
+
+#define LOG_THROTTLE_WINDOW_SEC 10
+
+struct log_throttle {
+	unsigned       suppressed;     /* events coalesced since the window opened */
+	struct timeval window_start;   /* tv_sec == 0 -> idle, no open window */
+};
+
+int log_throttle_allow(struct log_throttle *t, const struct timeval *now);
+unsigned log_throttle_flush_due(struct log_throttle *t, const struct timeval *now);
 
 struct log_field { const char *k, *v; };
 int log_format(char *out, size_t outsz, enum log_level lvl, int journal_mode,

--- a/sid_info.c
+++ b/sid_info.c
@@ -449,8 +449,9 @@ process_sid_info_response(struct sid_info *si, struct ber *e)
 		}
 	} else {
 		if (!TAILQ_EMPTY(&si->oids_being_queried)) {
-			log_warn("not all oids accounted for", "peer", peer_str(&cri->dest->dest_addr),
-			    "sid", U(si->sid), NULL);
+			if (destination_log_allow(cri->dest, LTC_OIDS_UNACCOUNTED))
+				log_warn("not all oids accounted for", "peer", peer_str(&cri->dest->dest_addr),
+				    "sid", U(si->sid), NULL);
 			all_oids_done(si, &BER_MISSING);
 		}
 	}
@@ -463,8 +464,9 @@ process_sid_info_response(struct sid_info *si, struct ber *e)
 	return 1;
 bad_snmp_packet:
 	PS.bad_snmp_responses++;
-	log_warn("bad SNMP packet, ignoring", "peer", peer_str(&cri->dest->dest_addr),
-	    "sid", U(si->sid), "trace", trace, NULL);
+	if (destination_log_allow(cri->dest, LTC_BAD_PACKET))
+		log_warn("bad SNMP packet, ignoring", "peer", peer_str(&cri->dest->dest_addr),
+		    "sid", U(si->sid), "trace", trace, NULL);
 	return 0;
 }
 

--- a/snmp.c
+++ b/snmp.c
@@ -28,7 +28,8 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 	PS.octets_received += n;
 	dest = find_destination(&from->sin_addr, ntohs(from->sin_port));
 	if (!dest) {
-		log_warn("destination not known, ignoring packet", "peer", peer, NULL);
+		if (log_throttle_allow_standalone(LTC_UNKNOWN_DESTINATION))
+			log_warn("destination not known, ignoring packet", "peer", peer, NULL);
 		return;
 	}
 	dest->octets_received += n;
@@ -60,7 +61,8 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
 		si = find_sid_info(dest, sid);
 		if (!si) {
-			log_info("late reply, ignoring packet", "peer", peer, "sid", U(sid), NULL);
+			if (destination_log_allow(dest, LTC_LATE_REPLY))
+				log_info("late reply, ignoring packet", "peer", peer, "sid", U(sid), NULL);
 			return;
 		}
 
@@ -118,14 +120,16 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
 		si = find_sid_info(dest, mid);
 		if (!si) {
-			log_info("late reply, ignoring packet", "peer", peer, "mid", U(mid), NULL);
+			if (destination_log_allow(dest, LTC_LATE_REPLY))
+				log_info("late reply, ignoring packet", "peer", peer, "mid", U(mid), NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
 		}
 
 		// - ignore if no si->v3 setup
 		if (si->cri->version != 3 || !si->cri->v3) {
-			log_warn("no v3 info for reply, ignoring packet", "peer", peer, "mid", U(mid), NULL);
+			if (destination_log_allow(dest, LTC_NO_V3_INFO))
+				log_warn("no v3 info for reply, ignoring packet", "peer", peer, "mid", U(mid), NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
 		}
@@ -145,16 +149,18 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 				p += snprintf(known+p, sizeof(known)-p, "%02x", siv3->engine_id[i]);
 			for (p = 0, i = 0; i < v3.engine_id_len; i++)
 				p += snprintf(received+p, sizeof(received)-p, "%02x", v3.engine_id[i]);
-			log_warn("engine-id mismatch, ignoring packet", "peer", peer, "mid", U(mid),
-					"known_engine_id", known, "recv_engine_id", received, NULL);
+			if (destination_log_allow(dest, LTC_ENGINE_ID_MISMATCH))
+				log_warn("engine-id mismatch, ignoring packet", "peer", peer, "mid", U(mid),
+						"known_engine_id", known, "recv_engine_id", received, NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
         }
 
 		// - verify username
 		if (strcmp(siv3->username, v3.username) != 0) {
-			log_warn("username mismatch, ignoring packet", "peer", peer, "mid", U(mid),
-					"known_username", siv3->username, "username", v3.username, NULL);
+			if (destination_log_allow(dest, LTC_USERNAME_MISMATCH))
+				log_warn("username mismatch, ignoring packet", "peer", peer, "mid", U(mid),
+						"known_username", siv3->username, "username", v3.username, NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
 		}
@@ -174,8 +180,9 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 			memset(auth_param_ptr, 0, maclen); // clear original HMAC location for auth calculations
     		if (hmac_message(siv3, auth_param_ptr, maclen, e->buf, e->max_len, auth_param_ptr) < 0) {
 				memcpy(auth_param_ptr, auth_param, maclen);
-				log_warn("authentication failed", "peer", peer, "mid", U(mid),
-						"error", strerror(errno), NULL);
+				if (destination_log_allow(dest, LTC_AUTH_FAILED))
+					log_warn("authentication failed", "peer", peer, "mid", U(mid),
+							"error", strerror(errno), NULL);
 				log_debug("authentication failed", "peer", peer, "mid", U(mid),
 						"packet", HEXBUF(e->buf, e->max_len), NULL);
 				trace = NULL;
@@ -186,7 +193,8 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
 				snprintf(auth_calc, sizeof(auth_calc), "%s", HEXBUF(auth_param_ptr, maclen));
 				memcpy(auth_param_ptr, auth_param, maclen);
-				log_warn("authentication failed", "peer", peer, "mid", U(mid), NULL);
+				if (destination_log_allow(dest, LTC_AUTH_FAILED))
+					log_warn("authentication failed", "peer", peer, "mid", U(mid), NULL);
 				log_debug("authentication failed", "peer", peer, "mid", U(mid),
 						"auth_calc", auth_calc,
 						"packet", HEXBUF(e->buf, e->max_len), NULL);
@@ -206,7 +214,8 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
         	if (t != AT_STRING) goto bad_snmp_packet;
 			// - decrypt
 			if (decrypt_in_place(e->b, l, priv_param, siv3) < 0) {
-				log_warn("cannot decrypt, ignoring packet", "peer", peer, "mid", U(mid), NULL);
+				if (destination_log_allow(dest, LTC_CANNOT_DECRYPT))
+					log_warn("cannot decrypt, ignoring packet", "peer", peer, "mid", U(mid), NULL);
 				trace = NULL;
 				goto bad_snmp_packet;
 			}
@@ -225,8 +234,9 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 				p += snprintf(authoritative+p, sizeof(authoritative)-p, "%02x", v3.engine_id[i]);
 			for (p = 0, i = 0; i < l; i++)
 				p += snprintf(context+p, sizeof(context)-p, "%02x", context_engine_id[i]);
-			log_warn("authoritative/context engine-id mismatch, ignoring packet", "peer", peer,
-					"mid", U(mid), "auth_engine_id", authoritative, "context_engine_id", context, NULL);
+			if (destination_log_allow(dest, LTC_AUTHCTX_ENGINE_MISMATCH))
+				log_warn("authoritative/context engine-id mismatch, ignoring packet", "peer", peer,
+						"mid", U(mid), "auth_engine_id", authoritative, "context_engine_id", context, NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
         }
@@ -244,8 +254,9 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 		}
 		t = e->b[0];
 		if (t != PDU_REPORT && t != PDU_GET_RESPONSE) {
-			log_warn("unsupported PDU type, ignoring packet", "peer", peer, "mid", U(mid),
-					"pdu_type", HEX(t), NULL);
+			if (destination_log_allow(dest, LTC_UNSUPPORTED_PDU))
+				log_warn("unsupported PDU type, ignoring packet", "peer", peer, "mid", U(mid),
+						"pdu_type", HEX(t), NULL);
 			trace = NULL;
 			goto bad_snmp_packet;
 		}
@@ -256,7 +267,7 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 		if (sid != mid) {
 			// if our request HMAC is wrong, some implementations return 0x7fffffff
 			// to be on the safe side, we generally ignore sid != mid situation
-			if (sid != 0x7fffffff)
+			if (sid != 0x7fffffff && destination_log_allow(dest, LTC_MSGID_MISMATCH))
 				log_warn("message-id does not match request-id", "peer", peer,
 						"mid", U(mid), "sid", U(sid), NULL);
 		}
@@ -268,15 +279,13 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 			struct ber oid, val;
 
 			CHECK("error-status", decode_integer(e, -1, &error_status));
-			if (error_status != 0) {
+			if (error_status != 0 && destination_log_allow(dest, LTC_ERROR_STATUS))
 				log_warn("non-zero error-status", "peer", peer, "mid", U(mid),
 						"error_status", I(error_status), NULL);
-			}
 			CHECK("error-index", decode_integer(e, -1, &error_index));
-			if (error_index != 0) {
+			if (error_index != 0 && destination_log_allow(dest, LTC_ERROR_INDEX))
 				log_warn("non-zero error-index", "peer", peer, "mid", U(mid),
 						"error_index", I(error_index), NULL);
-			}
 
 			// - analyze varbinds and report
 			CHECK("var-binds", decode_sequence(e, &oids_stop));
@@ -292,11 +301,13 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 					resend_query_with_new_sid(si);
 					return;
 				} else if (oid_compare(&oid, &usmStatsWrongDigests) == 0) {
-					log_warn("report: bad digest, ignoring packet", "peer", peer, "mid", U(mid), NULL);
+					if (destination_log_allow(dest, LTC_REPORT_BAD_DIGEST))
+						log_warn("report: bad digest, ignoring packet", "peer", peer, "mid", U(mid), NULL);
 					trace = NULL;
 					goto bad_snmp_packet;
 				} else {
-					log_warn("report", "peer", peer, "mid", U(mid), "oid", oid2str(oid), NULL);
+					if (destination_log_allow(dest, LTC_REPORT))
+						log_warn("report", "peer", peer, "mid", U(mid), "oid", oid2str(oid), NULL);
 					log_debug("report", "peer", peer, "mid", U(mid),
 							"value", HEXBUF(val.buf, (size_t)val.len), NULL);
 					trace = NULL;
@@ -322,7 +333,7 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 
 bad_snmp_packet:
 	PS.bad_snmp_responses++;
-	if (trace)
+	if (trace && destination_log_allow(dest, LTC_BAD_PACKET))
 		log_warn("bad SNMP packet, ignoring", "peer", peer, "trace", trace, NULL);
 	maybe_query_destination(dest);
 }
@@ -396,6 +407,9 @@ void snmp_send(struct destination *dest, struct ber *packet)
 			   sizeof(dest->dest_addr));
 	if (n < 0) {
 		if (errno == EAGAIN) {
+			if (log_throttle_allow_standalone(LTC_SEND_BUFFER_OVERFLOW))
+				log_warn("udp send buffer overflow, dropping datagram",
+					"peer", peer_str(&dest->dest_addr), NULL);
 			PS.udp_send_buffer_overflow++;
 			return;
 		}

--- a/sqe.h
+++ b/sqe.h
@@ -303,6 +303,10 @@ struct destination
 	/* destination-specific stats */
 	int64_t octets_received;
 	int64_t octets_sent;
+
+	/* lazily-allocated per-destination log-throttle counters,
+	   indexed by the per-destination log_throttle_cat values */
+	struct log_throttle *throttle;
 };
 
 #define V3O_ENGINE_ID_MAXLEN 64
@@ -558,6 +562,8 @@ extern void destination_stop_timing(struct destination *dest);
 extern void destination_timer(struct destination *dest);
 extern void dump_all_destinations(msgpack_packer *pk);
 extern void unclog_all_destinations(void);
+extern int destination_log_allow(struct destination *dest, enum log_throttle_cat cat);
+extern void flush_destination_log_rollups(const struct timeval *now);
 
 /* client_requests_info.c */
 extern struct client_requests_info *get_client_requests_info(struct in_addr *ip, unsigned port, struct socket_info *si);

--- a/t/logging.t
+++ b/t/logging.t
@@ -149,4 +149,24 @@ subtest 'shutdown reason' => sub {
 		'shutdown line names the signal that triggered it');
 };
 
+subtest 'per-destination anomaly logs coalesce' => sub {
+	my $log = File::Temp->new;
+	my $d = spawn_daemon(args => [], stderr_file => "$log");
+	my $agent = SQE::FakeAgent->spawn(
+		tree      => [['1.3.6.1.2.1.1.5.0', str => 'x']],
+		malformed => 'garbage',
+	);
+	my $port = $agent->port;
+	# fast timeout + retries so several garbage replies arrive within one window
+	$d->request([RT_SETOPT, 1, "127.0.0.1", $port, {timeout => 50, retries => 2}]);
+	for my $id (2 .. 4) {
+		$d->request([RT_GET, $id, "127.0.0.1", $port, ["1.3.6.1.2.1.1.5.0"]]);
+	}
+	$d->stop;
+	my $text = slurp("$log");
+	my @immediate = $text =~ /msg="bad SNMP packet, ignoring"[^\n]*trace=/g;
+	is(scalar @immediate, 1,
+		'repeated bad-packet anomalies from one agent coalesce to a single immediate line');
+};
+
 done_testing;

--- a/t/logging.t
+++ b/t/logging.t
@@ -169,4 +169,25 @@ subtest 'per-destination anomaly logs coalesce' => sub {
 		'repeated bad-packet anomalies from one agent coalesce to a single immediate line');
 };
 
+subtest 'client churn notices coalesce' => sub {
+	my $log = File::Temp->new;
+	my $d = spawn_daemon(args => [], stderr_file => "$log");   # opens connection #1
+	my $port = $d->port;
+	my @extra;
+	for (1 .. 3) {
+		my $c = IO::Socket::INET->new(PeerAddr => "127.0.0.1:$port", Proto => "tcp")
+			or die "connect: $!";
+		push @extra, $c;
+	}
+	Time::HiRes::sleep(0.1);
+	$_->close for @extra;
+	Time::HiRes::sleep(0.1);
+	$d->stop;
+	my $text = slurp("$log");
+	my @conn = $text =~ /msg="incoming connection" peer=\S+ fd=\d+/g;
+	my @disc = $text =~ /msg="client disconnect" fd=\d+/g;
+	is(scalar @conn, 1, 'repeated incoming connections coalesce to one immediate line');
+	is(scalar @disc, 1, 'repeated client disconnects coalesce to one immediate line');
+};
+
 done_testing;

--- a/t/test_throttle.c
+++ b/t/test_throttle.c
@@ -1,0 +1,47 @@
+/* ABOUTME: Unit tests for the log_throttle windowed-coalescing primitive:
+ * ABOUTME: allow accounting and flush_due window/reset logic with an injected clock. */
+#include "../sqe.h"
+#include "tap.h"
+
+static struct timeval
+tv(long sec)
+{
+	struct timeval t;
+	t.tv_sec = sec;
+	t.tv_usec = 0;
+	return t;
+}
+
+int
+main(void)
+{
+	struct log_throttle t;
+	struct timeval now;
+
+	memset(&t, 0, sizeof(t));
+
+	now = tv(1000);
+	ok(log_throttle_allow(&t, &now) == 1, "first event in window is allowed");
+	ok(log_throttle_allow(&t, &now) == 0, "second event is suppressed");
+	ok(log_throttle_allow(&t, &now) == 0, "third event is suppressed");
+	is_int(t.suppressed, 2, "two events suppressed");
+
+	now = tv(1005);	/* 5s < 10s window */
+	is_int(log_throttle_flush_due(&t, &now), 0, "flush before window close returns 0");
+	is_int(t.suppressed, 2, "counter unchanged before window close");
+
+	now = tv(1011);	/* 11s >= 10s window */
+	is_int(log_throttle_flush_due(&t, &now), 2, "flush at window close returns suppressed count");
+	is_int(t.window_start.tv_sec, 0, "counter reset to idle after flush");
+
+	now = tv(1011);
+	ok(log_throttle_allow(&t, &now) == 1, "next event re-opens the window");
+
+	now = tv(1022);
+	is_int(log_throttle_flush_due(&t, &now), 0, "empty window flush returns 0");
+	is_int(t.window_start.tv_sec, 0, "empty window still resets to idle");
+
+	is_int(log_throttle_flush_due(&t, &now), 0, "flush on idle counter returns 0");
+
+	return tap_done();
+}

--- a/t/test_throttle.c
+++ b/t/test_throttle.c
@@ -43,5 +43,43 @@ main(void)
 
 	is_int(log_throttle_flush_due(&t, &now), 0, "flush on idle counter returns 0");
 
+	/* --- category table is fully populated --- */
+	{
+		int cat, all_ok = 1;
+		for (cat = 0; cat < LTC_COUNT; cat++)
+			if (log_throttle_cat_message(cat) == NULL)
+				all_ok = 0;
+		ok(all_ok, "every category has a message");
+	}
+
+	/* --- standalone adapter: first allowed, repeats suppressed in-window --- */
+	{
+		int a = log_throttle_allow_standalone(LTC_UNKNOWN_DESTINATION);
+		int b = log_throttle_allow_standalone(LTC_UNKNOWN_DESTINATION);
+		int c = log_throttle_allow_standalone(LTC_UNKNOWN_DESTINATION);
+		ok(a == 1 && b == 0 && c == 0, "standalone: first allowed, repeats suppressed");
+	}
+
+	/* --- per-destination adapter: lazy alloc + in-window suppression --- */
+	{
+		struct destination d;
+		unsigned n;
+		struct timeval future;
+
+		memset(&d, 0, sizeof(d));
+		ok(d.throttle == NULL, "destination starts with no throttle array");
+		ok(destination_log_allow(&d, LTC_BAD_PACKET) == 1, "per-dest: first allowed");
+		ok(d.throttle != NULL, "throttle array lazily allocated on first use");
+		ok(destination_log_allow(&d, LTC_BAD_PACKET) == 0, "per-dest: repeat suppressed");
+		ok(destination_log_allow(&d, LTC_BAD_PACKET) == 0, "per-dest: repeat suppressed");
+		is_int(d.throttle[LTC_BAD_PACKET].suppressed, 2, "per-dest: two suppressed");
+
+		future = d.throttle[LTC_BAD_PACKET].window_start;
+		future.tv_sec += LOG_THROTTLE_WINDOW_SEC + 1;
+		n = log_throttle_flush_due(&d.throttle[LTC_BAD_PACKET], &future);
+		is_int(n, 2, "per-dest: flush after window returns suppressed count");
+		free(d.throttle);
+	}
+
 	return tap_done();
 }

--- a/t/throttle.t
+++ b/t/throttle.t
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec "$(dirname "$0")/test_throttle"

--- a/timers.c
+++ b/timers.c
@@ -140,6 +140,8 @@ trigger_timers(void)
 	if (last_unclog.tv_sec < now.tv_sec) {
 		last_unclog = now;
 		unclog_all_destinations();
+		flush_destination_log_rollups(&now);
+		log_throttle_flush_standalone(&now);
 	}
 
 again:


### PR DESCRIPTION
## Summary

Repeated per-agent SNMP anomalies and per-connection client churn could
previously drive log output without bound — a misbehaving or hostile agent
could flood the log with thousands of lines per second. This adds windowed
coalescing: the first event per key in a 10-second window logs immediately
with full detail; the rest are counted and rolled up into a single
`… repeated=N interval_s=10` line when the window closes.

Storm cost drops to at most one detailed line plus one rollup per 10 s per
key. The UDP send-buffer overflow, previously dropped silently, now gets a
throttled notice so operators can tell sends are being lost; its statistics
counter stays exact and unconditional.

## Details

- Pure clock-injected coalescing primitive, unit-tested with a fake clock.
- One category per distinct message; per-destination counters are lazily
  allocated only for hosts that actually misbehave, so memory scales with
  misbehaving hosts, not fleet size.
- Rollups piggyback the existing once-per-second housekeeping tick — no new
  timer machinery. `log_debug` output is left unthrottled (it's opt-in).

## Test plan

- [x] New C unit tier `t/throttle.t` (fake-clock primitive + glue), 21 assertions
- [x] `t/logging.t` extended: per-destination anomaly coalescing + client-churn coalescing subtests
- [x] Full suite: 343 tests pass (`make test`)
- [x] `scan-build` clean — No bugs found
- [x] Clean `-Werror` build
