### PR TITLE
docs: clarify GETTABLE empty-reply and error semantics

### DIFF
--- a/.changes/unreleased/Fixed-20260708-132201.yaml
+++ b/.changes/unreleased/Fixed-20260708-132201.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'manual: clarify GETTABLE empty replies and errors'
+time: 2026-07-08T13:22:01.942457+02:00

--- a/manual.mdwn
+++ b/manual.mdwn
@@ -718,6 +718,20 @@ non-increasing
     no further attempts to continue iterating
     the table
 
+In practice, the "no-such-object" and "no-such-instance"
+errors never occur in **GETTABLE** replies, because
+the underlying SNMP get-next and get-bulk queries
+do not produce them.
+
+A successful reply with an empty array means that
+no oids exist under the requested oid.  This happens
+both when the table is empty and when the destination
+does not implement the table at all:  SNMP get-next
+and get-bulk queries cannot distinguish between these
+two cases, so, unlike **GET**, an attempt to walk
+a non-existent table is not reported as
+a "no-such-object" error.
+
 The requested table oid is never present in the reply itself
 if there were no errors.
 
@@ -733,7 +747,9 @@ Example request 2:
 
     [GETTABLE, $id, "127.0.0.1", 161, "1.3.6.1.2.1.1.5.0"]
 
-Example reply 2 ("empty table"):
+Example reply 2 ("no oids under the requested oid" -
+here because a leaf oid was requested;  an empty or
+non-existent table produces the same reply):
 
     [GETTABLE|0x10, $id, []]
 

--- a/snmp-query-engine.1
+++ b/snmp-query-engine.1
@@ -672,6 +672,18 @@ non\-increasing
 this oid is less than or equal than the previous oid in the table; there
 will be no further attempts to continue iterating the table
 .PP
+In practice, the \(lqno\-such\-object\(rq and \(lqno\-such\-instance\(rq
+errors never occur in \f[B]GETTABLE\f[R] replies, because the underlying
+SNMP get\-next and get\-bulk queries do not produce them.
+.PP
+A successful reply with an empty array means that no oids exist under
+the requested oid.
+This happens both when the table is empty and when the destination does
+not implement the table at all: SNMP get\-next and get\-bulk queries
+cannot distinguish between these two cases, so, unlike \f[B]GET\f[R], an
+attempt to walk a non\-existent table is not reported as a
+\(lqno\-such\-object\(rq error.
+.PP
 The requested table oid is never present in the reply itself if there
 were no errors.
 .PP
@@ -693,7 +705,9 @@ Example request 2:
 [GETTABLE, $id, \(dq127.0.0.1\(dq, 161, \(dq1.3.6.1.2.1.1.5.0\(dq]
 .EE
 .PP
-Example reply 2 (\(lqempty table\(rq):
+Example reply 2 (\(lqno oids under the requested oid\(rq \- here because
+a leaf oid was requested; an empty or non\-existent table produces the
+same reply):
 .IP
 .EX
 [GETTABLE|0x10, $id, []]


### PR DESCRIPTION
Fixes #1.

The manual said GETTABLE's possible per-oid errors are "the same as in
GET", which set the expectation that walking a non-existent table
returns a "no-such-object" error the way GET does. It doesn't: the
underlying get-next/get-bulk queries cannot distinguish an empty table
from one the agent does not implement, so both produce a successful
reply with an empty array.

Manual changes (man page regenerated with pandoc):

- state that "no-such-object" / "no-such-instance" never occur in
  GETTABLE replies;
- explain that an empty reply array is a successful reply covering both
  the empty-table and non-existent-table cases;
- relabel example reply 2, which previously showed the empty reply only
  for the special case of walking a leaf oid.

Documentation only; no behavior change.