### PR TITLE
ci: bound job runtime so wedged runners fail fast

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies (Linux)
@@ -69,6 +70,7 @@ jobs:
 
   sanitize:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     env:
       ASAN_OPTIONS: detect_leaks=0
       UBSAN_OPTIONS: halt_on_error=1:print_stacktrace=1:abort_on_error=1


### PR DESCRIPTION
A push run on main recently sat for 15 minutes with all three jobs stuck
(a hosted-runner infrastructure stall — the identical commit passed on
re-run and in its PR run), and without a job timeout such a wedge would
occupy runners for GitHub's default 6 hours before failing.

Normal runs finish in about a minute, so cap the `test` matrix jobs at
10 minutes and `sanitize` at 15 (it shows more runner-speed variance
under ASan). A future infra hiccup now self-terminates and reports
failure promptly instead of hanging.

## Test plan

- [x] YAML parses cleanly
- [x] The workflow itself runs on this PR — checks going green validates
      the change end-to-end
