### PR TITLE
fix: bail from client_input when input buffer reservation fails

### DIFF
--- a/.changes/unreleased/Fixed-20260709-231656.yaml
+++ b/.changes/unreleased/Fixed-20260709-231656.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'client input: close the connection cleanly if memory runs out'
+time: 2026-07-09T23:16:56.499311+02:00

--- a/client_input.c
+++ b/client_input.c
@@ -28,6 +28,16 @@ client_gone(struct socket_info *si)
 		log_info("client disconnect", "fd", U((unsigned)fd), NULL);
 }
 
+int
+feed_client_unpacker(struct client_connection *c, const uint8_t *buf, size_t n)
+{
+	if (!msgpack_unpacker_reserve_buffer(&c->unpacker, n))
+		return -1;
+	memcpy(msgpack_unpacker_buffer(&c->unpacker), buf, n);
+	msgpack_unpacker_buffer_consumed(&c->unpacker, n);
+	return 0;
+}
+
 static void
 client_input(struct socket_info *si)
 {
@@ -55,9 +65,10 @@ client_input(struct socket_info *si)
 		return;
 	}
 
-	msgpack_unpacker_reserve_buffer(&c->unpacker, n);
-	memcpy(msgpack_unpacker_buffer(&c->unpacker), buf, n);
-	msgpack_unpacker_buffer_consumed(&c->unpacker, n);
+	if (feed_client_unpacker(c, buf, n) < 0) {
+		client_gone(si);
+		return;
+	}
 
 	while (msgpack_unpacker_next(&c->unpacker, &c->input)) {
 		msgpack_object *o;

--- a/sqe.h
+++ b/sqe.h
@@ -534,6 +534,7 @@ extern void snmp_send(struct destination *dest, struct ber *packet);
 
 /* client_input.c */
 extern void new_client_connection(int fd);
+extern int feed_client_unpacker(struct client_connection *c, const uint8_t *buf, size_t n);
 
 /* util.c */
 extern char *object_strdup(msgpack_object *o);

--- a/t/test_msgpack.c
+++ b/t/test_msgpack.c
@@ -96,5 +96,29 @@ main(void)
 	ok(!msgpack_unpacker_next(&unpacker, &result), "no extra objects");
 	msgpack_unpacked_destroy(&result);
 	msgpack_unpacker_destroy(&unpacker);
+
+	/* feed_client_unpacker() feeds a chunk into a connection's unpacker and
+	 * must report an allocation failure rather than memcpy into a buffer that
+	 * was never reserved. */
+	{
+		struct client_connection c;
+		msgpack_unpacked r;
+		const uint8_t doc[] = "\x92\x01\x02"; /* [1,2] */
+
+		msgpack_unpacker_init(&c.unpacker, MSGPACK_UNPACKER_INIT_BUFFER_SIZE);
+		msgpack_unpacked_init(&r);
+
+		is_int(feed_client_unpacker(&c, doc, 3), 0,
+		    "feed_client_unpacker accepts a normal chunk");
+		ok(msgpack_unpacker_next(&c.unpacker, &r), "fed document parses");
+		is_int(r.data.via.array.size, 2, "fed document has 2 elements");
+
+		is_int(feed_client_unpacker(&c, doc, (size_t)1 << 60), -1,
+		    "feed_client_unpacker reports reserve failure instead of overrunning");
+
+		msgpack_unpacked_destroy(&r);
+		msgpack_unpacker_destroy(&c.unpacker);
+	}
+
 	return tap_done();
 }

--- a/t/test_msgpack.c
+++ b/t/test_msgpack.c
@@ -11,6 +11,16 @@
 #include "sqe.h"
 #include "tap.h"
 
+/* One test deliberately asks the unpacker to reserve an impossibly large
+ * buffer so the reservation fails; under AddressSanitizer such a request aborts
+ * by default, so make the allocator return NULL instead.  Unused (harmless) in
+ * non-sanitizer builds. */
+const char *
+__asan_default_options(void)
+{
+	return "allocator_may_return_null=1";
+}
+
 /* Feed sz bytes into the unpacker without extracting objects. */
 static void
 feed(msgpack_unpacker *unpacker, const char *buf, int sz)


### PR DESCRIPTION
## What

`client_input()` fed freshly-read bytes into the connection's msgpack unpacker
without checking whether the buffer reservation succeeded. On an allocation
failure the reservation returns false, after which the code copied the read data
into a buffer that was never grown — a heap buffer overrun, reachable only under
memory exhaustion.

The read-and-feed logic is now factored into `feed_client_unpacker()`, which
reports a failed reservation instead of copying past the buffer. `client_input()`
tears the connection down via `client_gone()` on failure, matching how it already
handles EOF and peer resets.

## Why

Under memory pressure a client connection should be dropped cleanly rather than
corrupting the daemon's heap. Surfaced during review of a since-rejected PR that
misdiagnosed the surrounding code but pointed at this real (if minor) gap.

## Testing

- [x] New unit test in `t/test_msgpack.c` exercises `feed_client_unpacker()`:
      a normal chunk feeds and parses; an impossibly large reservation returns
      -1 instead of overrunning (this case segfaulted before the fix).
- [x] `make test` — full suite passes (397 tests).
- [x] `scan-build make` — "No bugs found".