### PR TITLE
feat: SNMPv3 engine ID discovery

### DIFF
--- a/.changes/unreleased/Added-20260711-140448.yaml
+++ b/.changes/unreleased/Added-20260711-140448.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'snmpv3: discover agent engine ID when engineid is omitted'
+time: 2026-07-11T14:04:48.151156+02:00

--- a/.changes/unreleased/Added-20260711-140449.yaml
+++ b/.changes/unreleased/Added-20260711-140449.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'snmpv3: fail requests fast on agent engine ID mismatch'
+time: 2026-07-11T14:04:49.175999+02:00

--- a/ber.c
+++ b/ber.c
@@ -404,6 +404,101 @@ finalize_snmp_packet(struct packet_builder *pb, struct ber *out_encoded_packet, 
     return pb->pi.sid_offset;
 }
 
+/// @brief Builds a complete RFC 3414 engine id discovery probe: noAuthNoPriv,
+/// empty engine id and username, zero boots/time, reportable flag set, and a
+/// GET PDU with no varbinds.  The result is malloc'd into *out_packet.
+/// @return 0 for success, -1 for failure, in which case errno is set
+int
+build_v3_discovery_packet(unsigned request_id, unsigned msg_max_size, struct ber *out_packet)
+{
+    unsigned char  buf[128];
+    struct ber     enc = ber_init(buf, sizeof(buf));
+    struct ber    *e = &enc;
+    unsigned char *packet_sequence, *gdata, *sec_params_string, *sec_params_seq, *scoped_pdu, *pdu;
+    unsigned char  msg_flags = V3F_REPORTABLE;
+    unsigned char  empty[1]  = {0};
+
+    SPACECHECK2;
+    packet_sequence    = e->b;
+    packet_sequence[0] = AT_SEQUENCE;
+    EXTEND2;
+    if (encode_integer(3, e, 0) < 0)                 /* version */
+        return -1;
+
+    SPACECHECK2;
+    gdata    = e->b;
+    gdata[0] = AT_SEQUENCE;
+    EXTEND2;
+    if (encode_integer(request_id, e, 4) < 0)        /* msgID */
+        return -1;
+    if (encode_integer(msg_max_size, e, 0) < 0)
+        return -1;
+    if (encode_bytes(&msg_flags, 1, e) < 0)
+        return -1;
+    if (encode_integer(3, e, 0) < 0)                 /* msgSecurityModel USM */
+        return -1;
+    if (encode_store_length(e, gdata) < 0)
+        return -1;
+
+    SPACECHECK2;
+    sec_params_string    = e->b;
+    sec_params_string[0] = AT_STRING;
+    EXTEND2;
+    SPACECHECK2;
+    sec_params_seq    = e->b;
+    sec_params_seq[0] = AT_SEQUENCE;
+    EXTEND2;
+    if (encode_bytes(empty, 0, e) < 0)               /* engine id */
+        return -1;
+    if (encode_integer(0, e, 0) < 0)                 /* boots */
+        return -1;
+    if (encode_integer(0, e, 0) < 0)                 /* time */
+        return -1;
+    if (encode_bytes(empty, 0, e) < 0)               /* username */
+        return -1;
+    if (encode_bytes(empty, 0, e) < 0)               /* auth params */
+        return -1;
+    if (encode_bytes(empty, 0, e) < 0)               /* priv params */
+        return -1;
+    if (encode_store_length(e, sec_params_seq) < 0)
+        return -1;
+    if (encode_store_length(e, sec_params_string) < 0)
+        return -1;
+
+    SPACECHECK2;
+    scoped_pdu    = e->b;
+    scoped_pdu[0] = AT_SEQUENCE;
+    EXTEND2;
+    if (encode_bytes(empty, 0, e) < 0)               /* context engine id */
+        return -1;
+    if (encode_bytes(empty, 0, e) < 0)               /* context name */
+        return -1;
+
+    SPACECHECK2;
+    pdu    = e->b;
+    pdu[0] = PDU_GET_REQUEST;
+    EXTEND2;
+    if (encode_integer(request_id, e, 4) < 0)
+        return -1;
+    if (encode_integer(0, e, 0) < 0)                 /* error-status */
+        return -1;
+    if (encode_integer(0, e, 0) < 0)                 /* error-index */
+        return -1;
+    SPACECHECK2;
+    e->b[0] = AT_SEQUENCE;                           /* empty varbind list */
+    e->b[1] = 0;
+    EXTEND2;
+    if (encode_store_length(e, pdu) < 0)
+        return -1;
+    if (encode_store_length(e, scoped_pdu) < 0)
+        return -1;
+    if (encode_store_length(e, packet_sequence) < 0)
+        return -1;
+
+    *out_packet = ber_dup(e);
+    return 0;
+}
+
 /// @brief Stores actual length of a composite starting at s and ending at e->b, moving memory block if needed;  think of it as a
 /// finalizer for the composite.
 /// @param e the ber structure
@@ -1166,6 +1261,7 @@ oid_compare(struct ber *aa, struct ber *bb)
 
 struct ber usmStatsNotInTimeWindows;
 struct ber usmStatsWrongDigests;
+struct ber usmStatsUnknownEngineIDs;
 
 int
 populate_well_known_oids(void)
@@ -1184,6 +1280,12 @@ populate_well_known_oids(void)
         return -1;
     }
     usmStatsWrongDigests = ber_dup(&e);
+
+    e = ber_init(tmp_buf, 2048);
+    if (encode_string_oid("1.3.6.1.6.3.15.1.1.4.0", -1, &e) < 0) {
+        return -1;
+    }
+    usmStatsUnknownEngineIDs = ber_dup(&e);
 
     return 0;
 }

--- a/ber.c
+++ b/ber.c
@@ -88,11 +88,22 @@ ber_equal(struct ber *b1, struct ber *b2)
 }
 
 struct ber
+ber_string_error(const char *error_string)
+{
+    char       buf[256];
+    struct ber b;
+
+    b = ber_init(buf, sizeof(buf));
+    if (encode_string(error_string, &b) < 0)
+        croakx(2, "ber_string_error: error string too long");
+    b.buf[0] = VAL_STRING_ERROR;
+    return ber_rewind(ber_dup(&b));
+}
+
+struct ber
 ber_error_status(int error_status)
 {
     char       error_string[40];
-    char       buf[64];
-    struct ber b;
 
     switch (error_status) {
     case 0:
@@ -155,10 +166,7 @@ ber_error_status(int error_status)
     default:
         sprintf(error_string, "error-status %d", error_status);
     }
-    b = ber_init(buf, 64);
-    encode_string(error_string, &b);
-    b.buf[0] = VAL_STRING_ERROR;
-    return ber_rewind(ber_dup(&b));
+    return ber_string_error(error_string);
 }
 
 int

--- a/client_requests_info.c
+++ b/client_requests_info.c
@@ -128,6 +128,28 @@ free_client_request_info(struct client_requests_info *cri)
 	return 1;
 }
 
+/* Fails every oid still queued (never sent) on this cri with the given
+ * value, delivering replies to the client as the cids complete. */
+void
+fail_queued_oids(struct client_requests_info *cri, struct ber *val)
+{
+	struct oid_info *oi, *oi_temp;
+	struct cid_info *ci;
+
+	TAILQ_FOREACH_SAFE(oi, &cri->oids_to_query, oid_list, oi_temp) {
+		ci = get_cid_info(cri, oi->cid);
+		if (!ci || ci->n_oids == 0)
+			croakx(2, "fail_queued_oids: cid_info unexpectedly missing");
+		oi->value = ber_rewind(ber_dup(val));
+		oi->sid = 0;
+		TAILQ_REMOVE(&cri->oids_to_query, oi, oid_list);
+		TAILQ_INSERT_TAIL(&ci->oids_done, oi, oid_list);
+		ci->n_oids_done++;
+		if (ci->n_oids_done == ci->n_oids)
+			cid_reply(ci, oi->last_known_table_entry ? RT_GETTABLE : RT_GET);
+	}
+}
+
 void
 dump_client_request_info(msgpack_packer *pk, struct client_requests_info *cri)
 {

--- a/event_loop.c
+++ b/event_loop.c
@@ -47,6 +47,8 @@ new_socket_info(int fd)
 	si->PS.max_packets_on_the_wire = -42;
 	si->PS.global_throttles = -42;
 	si->PS.program_version = -42;
+	si->PS.v3_engineid_discoveries = -42;
+	si->PS.v3_engineid_mismatches = -42;
 	si->PS.octets_received = -42;
 	si->PS.octets_sent = -42;
 	gettimeofday(&si->created, NULL);

--- a/manual.mdwn
+++ b/manual.mdwn
@@ -158,6 +158,15 @@ Supported options:
 :   Authoritative SNMP engine ID of the destination (for SNMPv3).  The default is **""**.
     Valid values must be (optionally space-separated) hex strings, for example
     "39 6a 66 39 4d 5a 35 6b 68 49 72 61".
+    If `engineid` is omitted, the engine discovers it from the agent on first
+    use (RFC 3414 discovery) and then treats it as fixed until the options are
+    set again.  Note the security tradeoff: omitting `engineid` means any
+    holder of the credentials can answer the discovery probe and impersonate
+    the agent.  When the same credentials are shared across a fleet of
+    devices, a pinned per-device `engineid` is the only thing binding a
+    session to a specific device — pin engineids in such deployments.
+    Localized keys (`authkul`/`privkul`) cannot be re-localized, so `engineid`
+    is required with them.
     This is a per destination/client option which does
     not affect other clients.
 
@@ -208,6 +217,26 @@ Supported options:
     It is an error to specify both `privpassword` and `privkul`.
     This is a per destination/client option which does
     not affect other clients.
+
+Any **SETOPT** request that contains at least one of the SNMPv3 options above
+(`engineid`, `username`, `authprotocol`, `authpassword`, `authkul`,
+`privprotocol`, `privpassword`, `privkul`) replaces the whole SNMPv3
+configuration for the destination/client session with the contents of that
+request;  SNMPv3 options from earlier requests are not carried over.
+Re-issuing such a request without `engineid` is also how a client asks for a
+fresh engine ID discovery, for example after a device swap.  The engine ID
+handling depends on the combination of options supplied:
+
+- **`engineid` present, passwords supplied**: the passwords are localized to
+  keys immediately.
+- **`engineid` present, localized keys supplied**: the keys are used as given.
+- **`engineid` absent, passwords supplied**: engine ID discovery;  the
+  passwords are localized once the engine ID has been discovered from the
+  agent on first use.  Until then, **GETOPT** returns empty `engineid`,
+  `authkul` and `privkul`;  after discovery it returns the discovered values,
+  which the client may store and use to pin the device later.
+- **`engineid` absent, localized keys supplied**: an error, "engineid is
+  required with authkul/privkul".
 
 **`global_max_packets`**
 :   Maximum global number of SNMP packets being "on the wire"
@@ -591,6 +620,13 @@ The following *global* statistics are available:
 **`uptime`**
 :   daemon uptime in milliseconds
 
+**`v3_engineid_discoveries`**
+:   number of times an SNMPv3 engine ID was discovered from an agent
+    (see the `engineid` option of the **SETOPT** request)
+
+**`v3_engineid_mismatches`**
+:   number of requests failed with an `engine-id-mismatch` error
+
 **`program_version`**
 :   numeric version of the engine program
     (frozen; see **`version`**)
@@ -663,8 +699,14 @@ unsupported type 0xHH
 :   the `snmp-query-engine` does not support
     values of this type (yet)
 
-XXXv3
-:   there are SNMPv3-related errors
+engine-id-mismatch: HEX
+:   the agent (or something claiming to be it) reported an SNMP engine ID
+    different from the configured or previously discovered one;  HEX is the
+    engine ID the peer claimed
+
+kul-calculation-error
+:   localizing the configured SNMPv3 passwords to keys failed after engine ID
+    discovery
 
 Example request:
 

--- a/request_info.c
+++ b/request_info.c
@@ -41,6 +41,8 @@ pack_stats(struct program_stats *PS, msgpack_packer *pk)
 	STAT(snmp_v1_sends);
 	STAT(snmp_v2c_sends);
 	STAT(snmp_v3_sends);
+	STAT(v3_engineid_discoveries);
+	STAT(v3_engineid_mismatches);
 	STAT(snmp_timeouts);
 	STAT(udp_timeouts);
 	STAT(bad_snmp_responses);

--- a/request_setopt.c
+++ b/request_setopt.c
@@ -89,6 +89,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 	int seen_authkul = 0;
 	int seen_privpassword = 0;
 	int seen_privkul = 0;
+	int seen_engineid = 0;
 
 	if (o->via.array.size != 5)
 		return error_reply(si, RT_SETOPT|RT_ERROR, cid, "bad request length");
@@ -108,10 +109,6 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 	memcpy(&d, cri->dest, sizeof(d));
 	memcpy(&c, cri, sizeof(c));
 	bzero(&v3, sizeof(v3));
-	if (c.v3) {
-		memcpy(&v3, cri->v3, sizeof(v3));
-		need_v3 = 1;
-	}
 
 	if (!option2index)
 		build_option2index();
@@ -208,6 +205,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 			if (v3.engine_id_len < 0)
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid engineid hexstring");
 			need_v3 = 1;
+			seen_engineid = 1;
 			break;
 		case OPT_username:
 			if (!object2string(v, v3.username, V3O_USERNAME_MAXSIZE))
@@ -299,7 +297,13 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 	if (seen_privpassword && seen_privkul)
 		return error_reply(si, RT_SETOPT|RT_ERROR, cid, "privpassword and privkul are mutually exclusive");
 
-	if (need_v3 && v3.authpass[0]) {
+	if (need_v3 && !seen_engineid) {
+		if (seen_authkul || seen_privkul)
+			return error_reply(si, RT_SETOPT|RT_ERROR, cid, "engineid is required with authkul/privkul");
+		v3.engine_state = V3_ENGINE_DISCOVERY;
+	}
+
+	if (need_v3 && v3.engine_state == V3_ENGINE_KNOWN && v3.authpass[0]) {
 		char *err;
 
         if (!password_to_kul(v3.auth_proto,
@@ -317,7 +321,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
         }
     }
 
-	if (need_v3 && v3.privpass[0]) {
+	if (need_v3 && v3.engine_state == V3_ENGINE_KNOWN && v3.privpass[0]) {
 		char *err;
 
         if (!password_to_kul(v3.auth_proto,
@@ -382,6 +386,8 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "malloc v3 problem");
 		}
 		memcpy(cri->v3, &v3, sizeof(v3));
+	} else if (cri->v3) {
+		cri->v3->msg_max_size = d.max_reply_packet_size;
 	}
 
 	buffer = msgpack_sbuffer_new();

--- a/sid_info.c
+++ b/sid_info.c
@@ -8,8 +8,8 @@
  */
 #include "sqe.h"
 
-struct sid_info *
-new_sid_info(struct client_requests_info *cri)
+static struct sid_info *
+alloc_sid_info(struct client_requests_info *cri)
 {
 	struct sid_info *si, **si_slot;
 	unsigned sid;
@@ -19,12 +19,12 @@ new_sid_info(struct client_requests_info *cri)
 	dest = cri->dest;
 	JLI(si_slot, dest->sid_info, sid);
 	if (si_slot == PJERR)
-		croak(2, "new_sid_info: JLI(sid_info) failed");
+		croak(2, "alloc_sid_info: JLI(sid_info) failed");
 	if (*si_slot)
-		croak(2, "new_sid_info: sid_info must not be there");
+		croak(2, "alloc_sid_info: sid_info must not be there");
 	si = malloc(sizeof(*si));
 	if (!si)
-		croak(2, "new_sid_info: malloc(sid_info)");
+		croak(2, "alloc_sid_info: malloc(sid_info)");
 
 	bzero(si, sizeof(*si));
 	si->sid = sid;
@@ -32,8 +32,6 @@ new_sid_info(struct client_requests_info *cri)
 	si->retries_left = cri->retries;
 	si->version = cri->version;
 	TAILQ_INIT(&si->oids_being_queried);
-	if (start_snmp_packet(&si->pb, si->version, sid, cri->v3, cri->community) < 0)
-		croak(2, "new_sid_info: start_snmp_get_packet");
 	*si_slot = si;
 	TAILQ_INSERT_TAIL(&cri->sid_infos, si, sid_list);
 
@@ -42,6 +40,44 @@ new_sid_info(struct client_requests_info *cri)
 	cri->si->PS.active_sid_infos++;
 	cri->si->PS.total_sid_infos++;
 	return si;
+}
+
+struct sid_info *
+new_sid_info(struct client_requests_info *cri)
+{
+	struct sid_info *si = alloc_sid_info(cri);
+
+	if (start_snmp_packet(&si->pb, si->version, si->sid, cri->v3, cri->community) < 0)
+		croak(2, "new_sid_info: start_snmp_get_packet");
+	return si;
+}
+
+static struct sid_info *
+new_probe_sid_info(struct client_requests_info *cri)
+{
+	struct sid_info *si = alloc_sid_info(cri);
+
+	si->probe = 1;
+	if (build_v3_discovery_packet(si->sid, cri->v3->msg_max_size, &si->packet) < 0)
+		croak(2, "new_probe_sid_info: build_v3_discovery_packet");
+	return si;
+}
+
+static void
+send_discovery_probe(struct client_requests_info *cri)
+{
+	struct sid_info *si;
+
+	si = new_probe_sid_info(cri);
+	cri->v3->probe_sid = si->sid;
+	sid_start_timing(si);
+	si->retries_left--;
+
+	PS.snmp_sends++;
+	cri->si->PS.snmp_sends++;
+	PS.snmp_v3_sends++;
+	cri->si->PS.snmp_v3_sends++;
+	snmp_send(cri->dest, &si->packet);
 }
 
 struct sid_info *
@@ -64,6 +100,15 @@ build_snmp_query(struct client_requests_info *cri)
 	int extra_size;
 
 	if (TAILQ_EMPTY(&cri->oids_to_query))	return; /* XXX */
+
+	if (cri->version == 3 && cri->v3 &&
+	    cri->v3->engine_state == V3_ENGINE_DISCOVERY)
+	{
+		/* queries hold in oids_to_query until the engine id is discovered */
+		if (!cri->v3->probe_sid)
+			send_discovery_probe(cri);
+		return;
+	}
 
 	dest = cri->dest;
 	si = new_sid_info(cri);
@@ -234,12 +279,21 @@ resend_query_with_new_sid(struct sid_info *si)
 {
 	struct sid_info **si_slot;
 	struct oid_info *oi;
+	unsigned old_sid;
 	Word_t rc;
 
 	JLD(rc, si->cri->dest->sid_info, si->sid);
+	old_sid = si->sid;
 	si->sid = next_sid();
 
-	if (si->cri->version == 3 && si->cri->v3) {
+	if (si->probe) {
+		free(si->packet.buf);
+		si->packet.buf = NULL;
+		if (build_v3_discovery_packet(si->sid, si->cri->v3->msg_max_size, &si->packet) < 0)
+			croak(2, "resend_query_with_new_sid: build_v3_discovery_packet");
+		if (si->cri->v3->probe_sid == old_sid)
+			si->cri->v3->probe_sid = si->sid;
+	} else if (si->cri->version == 3 && si->cri->v3) {
 		regenerate_v3_packet(si);
 	} else {
 		si->packet.buf[si->pi.sid_offset+0] = (si->sid >> 24) & 0xff;
@@ -299,7 +353,16 @@ sid_timer(struct sid_info *si)
 	PS.snmp_timeouts++;
 	si->cri->si->PS.snmp_timeouts++;
 
-	if (si->table_oid) {
+	if (si->probe) {
+		struct snmpv3info *v3 = si->cri->v3;
+
+		if (v3 && v3->engine_state == V3_ENGINE_DISCOVERY &&
+		    v3->probe_sid == si->sid)
+		{
+			v3->probe_sid = 0;
+			fail_queued_oids(si->cri, &BER_TIMEOUT);
+		}
+	} else if (si->table_oid) {
 		oid_done(si, si->table_oid, &BER_TIMEOUT, RT_GETTABLE, 0);
 		si->table_oid = NULL;
 	} else {

--- a/sid_info.c
+++ b/sid_info.c
@@ -222,6 +222,12 @@ free_sid_info(struct sid_info *si)
 	PS.active_sid_infos--;
 	si->cri->si->PS.active_sid_infos--;
 
+	/* Freeing the tracked discovery probe must clear probe_sid, otherwise the
+	 * cri stays in V3_ENGINE_DISCOVERY with a dead nonzero probe_sid and
+	 * build_snmp_query never sends another probe (every future query hangs). */
+	if (si->probe && si->cri->v3 && si->cri->v3->probe_sid == si->sid)
+		si->cri->v3->probe_sid = 0;
+
 	TAILQ_REMOVE(&si->cri->sid_infos, si, sid_list);
 	JLD(rc, si->cri->dest->sid_info, si->sid);
 	sid_stop_timing(si);

--- a/snmp-query-engine.1
+++ b/snmp-query-engine.1
@@ -132,6 +132,17 @@ Authoritative SNMP engine ID of the destination (for SNMPv3).
 The default is \f[B]\(lq\(lq\f[R].
 Valid values must be (optionally space\-separated) hex strings, for
 example \(lq39 6a 66 39 4d 5a 35 6b 68 49 72 61\(rq.
+If \f[CR]engineid\f[R] is omitted, the engine discovers it from the
+agent on first use (RFC 3414 discovery) and then treats it as fixed
+until the options are set again.
+Note the security tradeoff: omitting \f[CR]engineid\f[R] means any
+holder of the credentials can answer the discovery probe and impersonate
+the agent.
+When the same credentials are shared across a fleet of devices, a pinned
+per\-device \f[CR]engineid\f[R] is the only thing binding a session to a
+specific device \(em pin engineids in such deployments.
+Localized keys (\f[CR]authkul\f[R]/\f[CR]privkul\f[R]) cannot be
+re\-localized, so \f[CR]engineid\f[R] is required with them.
 This is a per destination/client option which does not affect other
 clients.
 .TP
@@ -186,6 +197,35 @@ It is an error to specify both \f[CR]privpassword\f[R] and
 \f[CR]privkul\f[R].
 This is a per destination/client option which does not affect other
 clients.
+.PP
+Any \f[B]SETOPT\f[R] request that contains at least one of the SNMPv3
+options above (\f[CR]engineid\f[R], \f[CR]username\f[R],
+\f[CR]authprotocol\f[R], \f[CR]authpassword\f[R], \f[CR]authkul\f[R],
+\f[CR]privprotocol\f[R], \f[CR]privpassword\f[R], \f[CR]privkul\f[R])
+replaces the whole SNMPv3 configuration for the destination/client
+session with the contents of that request; SNMPv3 options from earlier
+requests are not carried over.
+Re\-issuing such a request without \f[CR]engineid\f[R] is also how a
+client asks for a fresh engine ID discovery, for example after a device
+swap.
+The engine ID handling depends on the combination of options supplied:
+.IP \(bu 2
+\f[B]\f[CB]engineid\f[B] present, passwords supplied\f[R]: the passwords
+are localized to keys immediately.
+.IP \(bu 2
+\f[B]\f[CB]engineid\f[B] present, localized keys supplied\f[R]: the keys
+are used as given.
+.IP \(bu 2
+\f[B]\f[CB]engineid\f[B] absent, passwords supplied\f[R]: engine ID
+discovery; the passwords are localized once the engine ID has been
+discovered from the agent on first use.
+Until then, \f[B]GETOPT\f[R] returns empty \f[CR]engineid\f[R],
+\f[CR]authkul\f[R] and \f[CR]privkul\f[R]; after discovery it returns
+the discovered values, which the client may store and use to pin the
+device later.
+.IP \(bu 2
+\f[B]\f[CB]engineid\f[B] absent, localized keys supplied\f[R]: an error,
+\(lqengineid is required with authkul/privkul\(rq.
 .TP
 \f[B]\f[CB]global_max_packets\f[B]\f[R]
 Maximum global number of SNMP packets being \(lqon the wire\(rq at any
@@ -551,6 +591,13 @@ total number of \(lqsoft\(rq timeouts
 \f[B]\f[CB]uptime\f[B]\f[R]
 daemon uptime in milliseconds
 .TP
+\f[B]\f[CB]v3_engineid_discoveries\f[B]\f[R]
+number of times an SNMPv3 engine ID was discovered from an agent (see
+the \f[CR]engineid\f[R] option of the \f[B]SETOPT\f[R] request)
+.TP
+\f[B]\f[CB]v3_engineid_mismatches\f[B]\f[R]
+number of requests failed with an \f[CR]engine\-id\-mismatch\f[R] error
+.TP
 \f[B]\f[CB]program_version\f[B]\f[R]
 numeric version of the engine program (frozen; see
 \f[B]\f[CB]version\f[B]\f[R])
@@ -617,8 +664,14 @@ unsupported type 0xHH
 the \f[CR]snmp\-query\-engine\f[R] does not support values of this type
 (yet)
 .TP
-XXXv3
-there are SNMPv3\-related errors
+engine\-id\-mismatch: HEX
+the agent (or something claiming to be it) reported an SNMP engine ID
+different from the configured or previously discovered one; HEX is the
+engine ID the peer claimed
+.TP
+kul\-calculation\-error
+localizing the configured SNMPv3 passwords to keys failed after engine
+ID discovery
 .PP
 Example request:
 .IP

--- a/snmp.c
+++ b/snmp.c
@@ -122,6 +122,45 @@ kul_error:
 	return 1;
 }
 
+/* Fails all of a sid's oids with ["engine-id-mismatch: <hex>"] carrying the
+ * engine id the peer claimed.  Only the one request fails; the cri keeps its
+ * configuration, so a corrected setopt recovers instantly. */
+static void
+fail_sid_engine_id_mismatch(struct sid_info *si, struct snmpv3info *pkt_v3,
+                            const char *peer, struct destination *dest)
+{
+	char known[2*V3O_ENGINE_ID_MAXLEN+1] = "";
+	char received[2*V3O_ENGINE_ID_MAXLEN+1] = "";
+	char errstr[2*V3O_ENGINE_ID_MAXLEN+32];
+	struct snmpv3info *siv3 = si->cri->v3;
+	struct ber errval;
+	int p, i;
+
+	for (p = 0, i = 0; i < siv3->engine_id_len; i++)
+		p += snprintf(known+p, sizeof(known)-p, "%02x", siv3->engine_id[i]);
+	for (p = 0, i = 0; i < pkt_v3->engine_id_len; i++)
+		p += snprintf(received+p, sizeof(received)-p, "%02x", pkt_v3->engine_id[i]);
+	snprintf(errstr, sizeof(errstr), "engine-id-mismatch: %s", received);
+
+	PS.v3_engineid_mismatches++;
+	if (destination_log_allow(dest, LTC_ENGINE_ID_MISMATCH))
+		log_warn("engine-id mismatch, failing request", "peer", peer, "mid", U(si->sid),
+				"known_engine_id", known, "recv_engine_id", received, NULL);
+
+	errval = ber_string_error(errstr);
+	errval.len = errval.max_len; /* oid_done/all_oids_done ber_dup() the encoded
+	                               * length, not the rewound decode position */
+	if (si->table_oid) {
+		oid_done(si, si->table_oid, &errval, RT_GETTABLE, 0);
+		si->table_oid = NULL;
+	} else {
+		all_oids_done(si, &errval);
+	}
+	free(errval.buf);
+	free_sid_info(si);
+	maybe_query_destination(dest);
+}
+
 static void
 snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *buf, int n)
 {
@@ -260,6 +299,13 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 					return;
 				trace = NULL;
 				goto bad_snmp_packet;
+			}
+
+			if (!(v3.msg_flags & V3F_ENCRYPTED) &&
+			    report_carries_usm_stat(*e, &usmStatsUnknownEngineIDs))
+			{
+				fail_sid_engine_id_mismatch(si, &v3, peer, dest);
+				return;
 			}
 
 			for (p = 0, i = 0; i < v3.engine_id_len; i++)

--- a/snmp.c
+++ b/snmp.c
@@ -12,6 +12,116 @@
 
 static struct socket_info *snmp = NULL;
 
+/* Checks (on a private copy of the parse state) whether an unencrypted reply,
+ * positioned at the scoped PDU, is a REPORT carrying the given usmStats oid. */
+static int
+report_carries_usm_stat(struct ber e, struct ber *stat_oid)
+{
+	unsigned char t;
+	unsigned char context_engine_id[V3O_ENGINE_ID_MAXLEN];
+	unsigned l, dummy;
+	int oids_stop;
+	struct ber oid, val;
+
+	if (decode_sequence(&e, NULL) < 0)                                      return 0;
+	if (decode_octets(&e, context_engine_id, V3O_ENGINE_ID_MAXLEN, &l) < 0) return 0;
+	if (decode_type_len(&e, &t, &l) < 0)                                    return 0;
+	if (t != AT_STRING)                                                     return 0;
+	e.b += l;   /* skip context-name */
+	e.len += l;
+	if (e.len + 1 > e.max_len)                                              return 0;
+	if (e.b[0] != PDU_REPORT)                                               return 0;
+	if (decode_composite(&e, PDU_REPORT, NULL) < 0)                         return 0;
+	if (decode_integer(&e, -1, &dummy) < 0)                                 return 0; /* request-id */
+	if (decode_integer(&e, -1, &dummy) < 0)                                 return 0; /* error-status */
+	if (decode_integer(&e, -1, &dummy) < 0)                                 return 0; /* error-index */
+	if (decode_sequence(&e, &oids_stop) < 0)                                return 0;
+	while (inside_sequence(&e, oids_stop)) {
+		if (decode_sequence(&e, NULL) < 0)                                  return 0;
+		if (decode_oid(&e, &oid) < 0)                                       return 0;
+		if (decode_any(&e, &val) < 0)                                       return 0;
+		if (oid_compare(&oid, stat_oid) == 0)                               return 1;
+	}
+	return 0;
+}
+
+/* Handles the REPORT answering an engine id discovery probe: adopts the
+ * agent's engine id, localizes the stored passwords against it, and releases
+ * the queries held during discovery.  Returns 1 when the packet was fully
+ * handled, 0 when the caller should ignore it via the bad-packet path. */
+static int
+adopt_discovered_engine_id(struct sid_info *si, struct snmpv3info *pkt_v3, struct ber *e,
+                           const char *peer, struct destination *dest)
+{
+	struct client_requests_info *cri = si->cri;
+	struct snmpv3info *siv3 = cri->v3;
+	char hex_eid[2*V3O_ENGINE_ID_MAXLEN+1] = "";
+	char *err;
+	int p, i;
+
+	if (siv3->engine_state != V3_ENGINE_DISCOVERY || siv3->probe_sid != si->sid) {
+		if (destination_log_allow(dest, LTC_REPORT))
+			log_info("reply to a stale discovery probe, ignoring packet",
+					"peer", peer, "mid", U(si->sid), NULL);
+		return 0;
+	}
+	if ((pkt_v3->msg_flags & V3F_ENCRYPTED) ||
+	    !report_carries_usm_stat(*e, &usmStatsUnknownEngineIDs))
+	{
+		if (destination_log_allow(dest, LTC_REPORT))
+			log_warn("unexpected reply to discovery probe, ignoring packet",
+					"peer", peer, "mid", U(si->sid), NULL);
+		return 0;
+	}
+
+	memcpy(siv3->engine_id, pkt_v3->engine_id, pkt_v3->engine_id_len);
+	siv3->engine_id_len = pkt_v3->engine_id_len;
+	siv3->engine_boots  = pkt_v3->engine_boots;
+	siv3->engine_time   = pkt_v3->engine_time;
+	for (p = 0, i = 0; i < siv3->engine_id_len; i++)
+		p += snprintf(hex_eid+p, sizeof(hex_eid)-p, "%02x", siv3->engine_id[i]);
+
+	if (siv3->authpass[0] &&
+	    !password_to_kul(siv3->auth_proto, siv3->authpass, strlen(siv3->authpass),
+	                     siv3->engine_id, siv3->engine_id_len,
+	                     siv3->authkul, V3O_AUTHKUL_MAXSIZE, &siv3->authkul_len, &err))
+		goto kul_error;
+	if (siv3->privpass[0]) {
+		if (!password_to_kul(siv3->auth_proto, siv3->privpass, strlen(siv3->privpass),
+		                     siv3->engine_id, siv3->engine_id_len,
+		                     siv3->privkul, V3O_PRIVKUL_MAXSIZE, &siv3->privkul_len, &err))
+			goto kul_error;
+		if (!expand_kul(siv3->auth_proto, siv3->priv_proto,
+		                siv3->privkul, siv3->privkul_len,
+		                siv3->engine_id, siv3->engine_id_len,
+		                siv3->x_privkul, V3O_PRIVKUL_MAXSIZE, &siv3->x_privkul_len, &err))
+			goto kul_error;
+	}
+
+	siv3->engine_state = V3_ENGINE_KNOWN;
+	siv3->probe_sid = 0;
+	PS.v3_engineid_discoveries++;
+	log_info("discovered engine id", "peer", peer, "engine_id", hex_eid, NULL);
+	free_sid_info(si);
+	maybe_query_destination(dest);
+	return 1;
+
+kul_error:
+	{
+		struct ber errval = ber_string_error("kul-calculation-error");
+
+		log_error("kul calculation error after engine id discovery",
+				"peer", peer, "engine_id", hex_eid, "error", err, NULL);
+		siv3->engine_id_len = 0;
+		siv3->probe_sid = 0;
+		fail_queued_oids(cri, &errval);
+		free(errval.buf);
+		free_sid_info(si);
+		maybe_query_destination(dest);
+	}
+	return 1;
+}
+
 static void
 snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *buf, int n)
 {
@@ -144,6 +254,13 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 			char known[2*V3O_ENGINE_ID_MAXLEN+1] = "";
 			char received[2*V3O_ENGINE_ID_MAXLEN+1] = "";
 			int p, i;
+
+			if (si->probe) {
+				if (adopt_discovered_engine_id(si, &v3, e, peer, dest))
+					return;
+				trace = NULL;
+				goto bad_snmp_packet;
+			}
 
 			for (p = 0, i = 0; i < v3.engine_id_len; i++)
 				p += snprintf(known+p, sizeof(known)-p, "%02x", siv3->engine_id[i]);

--- a/snmp.c
+++ b/snmp.c
@@ -110,6 +110,8 @@ kul_error:
 	{
 		struct ber errval = ber_string_error("kul-calculation-error");
 
+		errval.len = errval.max_len; /* fail_queued_oids ber_dup()s the encoded
+		                               * length, not the rewound decode position */
 		log_error("kul calculation error after engine id discovery",
 				"peer", peer, "engine_id", hex_eid, "error", err, NULL);
 		siv3->engine_id_len = 0;

--- a/snmp.c
+++ b/snmp.c
@@ -321,6 +321,19 @@ snmp_process_datagram(struct socket_info *snmp, struct sockaddr_in *from, char *
 			goto bad_snmp_packet;
         }
 
+		// - a discovery probe whose reply reached here carries an engine id equal
+		//   to the stored one (empty during discovery), so it bypassed the mismatch
+		//   branch where probe adoption lives.  A real discovery REPORT always
+		//   carries a non-empty engine id and goes through that branch; anything
+		//   else answering a probe is bogus and must never be processed as a GET.
+		if (si->probe) {
+			if (destination_log_allow(dest, LTC_REPORT))
+				log_warn("unexpected reply to discovery probe, ignoring packet",
+						"peer", peer, "mid", U(mid), NULL);
+			trace = NULL;
+			goto bad_snmp_packet;
+		}
+
 		// - verify username
 		if (strcmp(siv3->username, v3.username) != 0) {
 			if (destination_log_allow(dest, LTC_USERNAME_MISMATCH))

--- a/sqe.h
+++ b/sqe.h
@@ -449,6 +449,7 @@ extern struct ber ber_error_status(int error_status);
 
 extern struct ber usmStatsNotInTimeWindows;
 extern struct ber usmStatsWrongDigests;
+extern struct ber usmStatsUnknownEngineIDs;
 
 extern int populate_well_known_oids(void);
 
@@ -495,6 +496,7 @@ finalize_snmp_packet(struct packet_builder* pb,
                      struct packet_info* out_pi,
                      unsigned char type,
                      int max_repetitions);
+extern int build_v3_discovery_packet(unsigned request_id, unsigned msg_max_size, struct ber *out_packet);
 extern int oid_belongs_to_table(struct ber *oid, struct ber *table);
 extern int oid_compare(struct ber *aa, struct ber *bb);
 /* returns -9999 if there is a problem,

--- a/sqe.h
+++ b/sqe.h
@@ -447,6 +447,7 @@ extern void ber_dump(FILE *f, struct ber *e);
 extern int ber_equal(struct ber *b1, struct ber *b2);
 extern int ber_is_null(struct ber *ber);
 extern struct ber ber_error_status(int error_status);
+extern struct ber ber_string_error(const char *error_string);
 
 extern struct ber usmStatsNotInTimeWindows;
 extern struct ber usmStatsWrongDigests;

--- a/sqe.h
+++ b/sqe.h
@@ -335,6 +335,10 @@ struct destination
 #define V3F_ENCRYPTED		0x02
 #define V3F_AUTHENTICATED	0x01
 
+/* engine id acquisition state (struct snmpv3info.engine_state) */
+#define V3_ENGINE_KNOWN     0  /* engine id pinned via setopt, or discovered */
+#define V3_ENGINE_DISCOVERY 1  /* engine id unknown; discover it on first query */
+
 struct snmpv3info {
 	// these can be set via setopt and (mostly) obtained via getopt
 	unsigned  engine_id_len;
@@ -356,6 +360,9 @@ struct snmpv3info {
 	u_int32_t engine_boots;
 	u_int32_t engine_time;
 	u_int8_t  msg_flags;
+	// engine id acquisition (never packed by getopt)
+	int       engine_state;  /* V3_ENGINE_KNOWN / V3_ENGINE_DISCOVERY */
+	unsigned  probe_sid;     /* sid of the in-flight discovery probe, 0 = none */
 };
 
 struct client_requests_info

--- a/sqe.h
+++ b/sqe.h
@@ -411,6 +411,7 @@ struct sid_info
 	struct timeval will_timeout_at;
 	int retries_left;
 	unsigned version;
+	int probe;  /* engine id discovery probe; carries no oids */
 
 	struct packet_builder pb;
 	struct ber packet;
@@ -578,6 +579,7 @@ extern struct client_requests_info *get_client_requests_info(struct in_addr *ip,
 extern int free_client_request_info(struct client_requests_info *cri);
 extern int free_all_client_request_info_for_fd(int fd);
 extern void dump_client_request_info(msgpack_packer *pk, struct client_requests_info *cri);
+extern void fail_queued_oids(struct client_requests_info *cri, struct ber *val);
 
 /* cid_info.c */
 extern struct cid_info *get_cid_info(struct client_requests_info *cri, unsigned cid);

--- a/sqe.h
+++ b/sqe.h
@@ -142,6 +142,8 @@ struct program_stats
 	int64_t snmp_v1_sends;
 	int64_t snmp_v2c_sends;
 	int64_t snmp_v3_sends;
+	int64_t v3_engineid_discoveries;
+	int64_t v3_engineid_mismatches;
 	int64_t snmp_retries;
 	int64_t snmp_timeouts;
 	int64_t udp_timeouts;

--- a/t/behavior-v3.t
+++ b/t/behavior-v3.t
@@ -155,5 +155,30 @@ for my $i (0 .. $#faults) {
 	is($after->[2]{timeout}, 1500, 'non-v3 option still applied by the same setopt');
 }
 
+# probe timeout: held queries fail with plain ["timeout"], nothing else hits the wire
+{
+	my $asilent = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3, v3_never_sync => 1);
+	request_match($d, 'discovery setopt against a silent agent',
+		[RT_SETOPT, 520, $target, $asilent->port, {
+			version => 3, username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privpassword => $v3{priv_pass},
+			timeout => 100, retries => 2 }],
+		[RT_SETOPT|RT_REPLY, 520, T()]);
+	my $sends0 = $d->request([RT_INFO, 521])->[2]{global}{snmp_sends};
+	request_match($d, 'probe timeout fails all held oids with timeout',
+		[RT_GET, 522, $target, $asilent->port,
+			['1.3.6.1.2.1.1.5.0', '1.3.6.1.2.1.1.3.0']],
+		[RT_GET|RT_REPLY, 522, [
+			['1.3.6.1.2.1.1.5.0', ['timeout']],
+			['1.3.6.1.2.1.1.3.0', ['timeout']]]]);
+	my $sends1 = $d->request([RT_INFO, 523])->[2]{global}{snmp_sends};
+	is($sends1 - $sends0, 2, 'only the probe (2 sends) hit the wire, held oids never did');
+	request_match($d, 'engineid still empty after probe timeout',
+		[RT_GETOPT, 524, $target, $asilent->port],
+		[RT_GETOPT|RT_REPLY, 524, {engineid => ''}]);
+	$asilent->stop;
+}
+
 $d->stop;
 done_testing;

--- a/t/behavior-v3.t
+++ b/t/behavior-v3.t
@@ -130,5 +130,22 @@ for my $i (0 .. $#faults) {
 	$adisc->stop;
 }
 
+# a setopt with no v3 option keys at all must leave an existing v3 config
+# untouched, not rebuild or drop it
+{
+	my $before = $d->request([RT_GETOPT, 520, $target, $port]);
+	request_match($d, 'setopt with only non-v3 options',
+		[RT_SETOPT, 521, $target, $port, {timeout => 1500, max_reply_size => 800}],
+		[RT_SETOPT|RT_REPLY, 521, T()]);
+	my $after = $d->request([RT_GETOPT, 522, $target, $port]);
+	is($after->[2]{username},     $before->[2]{username},     'username survives v3-keyless setopt');
+	is($after->[2]{engineid},     $before->[2]{engineid},     'engineid survives v3-keyless setopt');
+	is($after->[2]{authprotocol}, $before->[2]{authprotocol}, 'authprotocol survives v3-keyless setopt');
+	is($after->[2]{authkul},      $before->[2]{authkul},      'authkul survives v3-keyless setopt');
+	is($after->[2]{privprotocol}, $before->[2]{privprotocol}, 'privprotocol survives v3-keyless setopt');
+	is($after->[2]{privkul},      $before->[2]{privkul},      'privkul survives v3-keyless setopt');
+	is($after->[2]{timeout}, 1500, 'non-v3 option still applied by the same setopt');
+}
+
 $d->stop;
 done_testing;

--- a/t/behavior-v3.t
+++ b/t/behavior-v3.t
@@ -281,5 +281,42 @@ for my $i (0 .. $#faults) {
 	$aswap2->stop;
 }
 
+# re-setopt while the probe is in flight: the stale probe's REPORT must not
+# adopt (nor fast-fail as a normal sid), and the held query survives to be
+# served under the new configuration
+{
+	my $aslow = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3, delay_ms => 500);
+	request_match($d, 'discovery setopt (slow agent)',
+		[RT_SETOPT, 570, $target, $aslow->port, {
+			version => 3, username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privpassword => $v3{priv_pass},
+			timeout => 1000, retries => 1 }],
+		[RT_SETOPT|RT_REPLY, 570, T()]);
+	my $g0 = $d->request([RT_INFO, 571])->[2]{global};
+	$d->lone_request([RT_GET, 572, $target, $aslow->port, ['1.3.6.1.2.1.1.5.0']]);
+	Time::HiRes::sleep(0.15);   # probe is out; its REPORT is still ~350ms away
+	request_match($d, 're-pin (to a wrong engine id) while the probe is in flight',
+		[RT_SETOPT, 573, $target, $aslow->port, {
+			version => 3, engineid => '80001f8804deadbeef', username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privpassword => $v3{priv_pass},
+			timeout => 1000, retries => 3 }],
+		[RT_SETOPT|RT_REPLY, 573, T()]);
+	my ($get) = $d->bulk_response;
+	is($get, to_check([RT_GET|RT_REPLY, 572,
+			[['1.3.6.1.2.1.1.5.0', ["engine-id-mismatch: $v3{engine_id}"]]]]),
+		'held query survives the re-setopt and fails under the new pin, not as a probe timeout');
+	my $g1 = $d->request([RT_INFO, 574])->[2]{global};
+	is($g1->{v3_engineid_discoveries} - $g0->{v3_engineid_discoveries}, 0,
+		'the stale probe reply did not adopt');
+	is($g1->{v3_engineid_mismatches} - $g0->{v3_engineid_mismatches}, 1,
+		'only the real query fast-failed; the stale probe reply was plain-ignored');
+	request_match($d, 'engine id is the re-pinned one, untouched by the stale probe',
+		[RT_GETOPT, 575, $target, $aslow->port],
+		[RT_GETOPT|RT_REPLY, 575, {engineid => '80001f8804deadbeef'}]);
+	$aslow->stop;
+}
+
 $d->stop;
 done_testing;

--- a/t/behavior-v3.t
+++ b/t/behavior-v3.t
@@ -9,6 +9,7 @@ use Test2::V0;
 use SQE::Test ':all';
 use SQE::FakeAgent;
 use SQE::USM;
+use Time::HiRes ();
 
 my $hostname = 'sqe-fake-v3';
 my @tree = (
@@ -220,6 +221,64 @@ for my $i (0 .. $#faults) {
 		[RT_GET, 541, $target, $adrop->port, ['1.3.6.1.2.1.1.5.0']],
 		[RT_GET|RT_REPLY, 541, [['1.3.6.1.2.1.1.5.0', $hostname]]]);
 	$adrop->stop;
+}
+
+# pinned mismatch: wrong pin fast-fails with the agent's claimed engine id
+{
+	my $amis = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3);
+	my $mm0 = $d->request([RT_INFO, 550])->[2]{global}{v3_engineid_mismatches};
+	request_match($d, 'pin a wrong engine id',
+		[RT_SETOPT, 551, $target, $amis->port, {
+			version => 3, engineid => '80001f8804deadbeef',
+			username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privpassword => $v3{priv_pass},
+			timeout => 2000, retries => 3 }],
+		[RT_SETOPT|RT_REPLY, 551, T()]);
+	my $t0 = Time::HiRes::time();
+	request_match($d, 'engine id mismatch fails the request fast',
+		[RT_GET, 552, $target, $amis->port, ['1.3.6.1.2.1.1.5.0']],
+		[RT_GET|RT_REPLY, 552,
+			[['1.3.6.1.2.1.1.5.0', ["engine-id-mismatch: $v3{engine_id}"]]]]);
+	ok(Time::HiRes::time() - $t0 < 1, 'mismatch failure arrives well under the timeout');
+	my $mm1 = $d->request([RT_INFO, 553])->[2]{global}{v3_engineid_mismatches};
+	is($mm1 - $mm0, 1, 'one engine id mismatch counted');
+	$amis->stop;
+}
+
+# discovered-then-pinned: a device swap after discovery fast-fails, and an
+# explicit re-setopt without engineid re-discovers
+{
+	my %v3new = (%v3, engine_id => '80001f88046e657765');
+	my $aswap = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3);
+	my %opts = (
+		version => 3, username => $v3{username},
+		authprotocol => 'sha256', authpassword => $v3{auth_pass},
+		privprotocol => 'aes128', privpassword => $v3{priv_pass},
+		timeout => 2000, retries => 3 );
+	request_match($d, 'discovery setopt (device-swap scenario)',
+		[RT_SETOPT, 560, $target, $aswap->port, \%opts],
+		[RT_SETOPT|RT_REPLY, 560, T()]);
+	request_match($d, 'initial discovery works',
+		[RT_GET, 561, $target, $aswap->port, ['1.3.6.1.2.1.1.5.0']],
+		[RT_GET|RT_REPLY, 561, [['1.3.6.1.2.1.1.5.0', $hostname]]]);
+	my $swap_port = $aswap->port;
+	$aswap->stop;
+	my $aswap2 = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3new, port => $swap_port);
+	request_match($d, 'device swap after discovery fast-fails (discovered == pinned)',
+		[RT_GET, 562, $target, $swap_port, ['1.3.6.1.2.1.1.5.0']],
+		[RT_GET|RT_REPLY, 562,
+			[['1.3.6.1.2.1.1.5.0', ["engine-id-mismatch: $v3new{engine_id}"]]]]);
+	request_match($d, 're-setopt without engineid triggers re-discovery',
+		[RT_SETOPT, 563, $target, $swap_port, \%opts],
+		[RT_SETOPT|RT_REPLY, 563, {engineid => ''}]);
+	request_match($d, 'get succeeds against the swapped device after re-discovery',
+		[RT_GET, 564, $target, $swap_port, ['1.3.6.1.2.1.1.5.0']],
+		[RT_GET|RT_REPLY, 564, [['1.3.6.1.2.1.1.5.0', $hostname]]]);
+	request_match($d, 'getopt shows the new discovered engine id',
+		[RT_GETOPT, 565, $target, $swap_port],
+		[RT_GETOPT|RT_REPLY, 565, {engineid => $v3new{engine_id}}]);
+	$aswap2->stop;
 }
 
 $d->stop;

--- a/t/behavior-v3.t
+++ b/t/behavior-v3.t
@@ -28,6 +28,14 @@ my $agent  = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3);
 my $target = '127.0.0.1';
 my $port   = $agent->port;
 
+{
+	my $info = $d->request([RT_INFO, 100])->[2];
+	is($info->{global}{v3_engineid_discoveries}, 0, 'v3_engineid_discoveries starts at 0');
+	is($info->{global}{v3_engineid_mismatches}, 0, 'v3_engineid_mismatches starts at 0');
+	ok(!exists $info->{connection}{v3_engineid_discoveries}, 'discoveries counter is global-only');
+	ok(!exists $info->{connection}{v3_engineid_mismatches}, 'mismatches counter is global-only');
+}
+
 request_match($d, 'set v3 credentials',
 	[RT_SETOPT, 200, $target, $port, {
 		version => 3, engineid => $v3{engine_id}, username => $v3{username},

--- a/t/behavior-v3.t
+++ b/t/behavior-v3.t
@@ -353,5 +353,72 @@ for my $i (0 .. $#faults) {
 	$abogus->stop;
 }
 
+# ignore-flush frees a live discovery probe: a normal sid timing out and
+# tripping ignore_threshold must not strand cri->v3->probe_sid, or every
+# later query on that destination hangs forever. (Route A for the
+# free_sid_info probe_sid clause; Route B, where the probe itself dies via
+# sid_timer and self-clears probe_sid, is covered by the stale-probe test
+# above.)
+{
+	my $asilent = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3, drop_all => 1);
+	my $ignport = $asilent->port;
+
+	request_match($d, 'pin v3 creds with a short timeout and ignore_threshold=1',
+		[RT_SETOPT, 590, $target, $ignport, {
+			version => 3, engineid => $v3{engine_id}, username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privpassword => $v3{priv_pass},
+			timeout => 150, retries => 1,
+			ignore_threshold => 1, ignore_duration => 300 }],
+		[RT_SETOPT|RT_REPLY, 590, T()]);
+
+	# GET1: a normal (non-probe) sid, sent under the pinned config above.
+	$d->lone_request([RT_GET, 591, $target, $ignport, ['1.3.6.1.2.1.1.5.0']]);
+
+	# Re-setopt into discovery mode on the same target/port while GET1's sid
+	# is still in flight; its own timeout (500ms) is well past GET1's (150ms)
+	# so the probe sent for GET2 below is still alive when GET1 times out.
+	request_match($d, 're-setopt to discovery mode while the normal sid is still in flight',
+		[RT_SETOPT, 592, $target, $ignport, {
+			version => 3, username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privpassword => $v3{priv_pass},
+			timeout => 500, retries => 1 }],
+		[RT_SETOPT|RT_REPLY, 592, {engineid => ''}]);
+
+	# GET2: held behind the discovery probe just sent for it.
+	$d->lone_request([RT_GET, 593, $target, $ignport, ['1.3.6.1.2.1.1.5.0']]);
+
+	# GET1 times out first and trips ignore_threshold; flush_ignored_destination
+	# must free the still-live discovery probe (and clear probe_sid) as part of
+	# ignoring GET2's held oid.
+	my @got;
+	local $SIG{ALRM} = sub { die "timed out waiting for GET1/GET2 replies\n" };
+	alarm(3);
+	push @got, $d->bulk_response while @got < 2;
+	alarm(0);
+	my %by_cid = map { ($_->[1], $_) } @got;
+	is($by_cid{591}, to_check([RT_GET|RT_REPLY, 591, [['1.3.6.1.2.1.1.5.0', ['timeout']]]]),
+		'GET1 times out normally and trips the destination ignore threshold');
+	is($by_cid{593}, to_check([RT_GET|RT_REPLY, 593, [['1.3.6.1.2.1.1.5.0', ['ignored']]]]),
+		'GET2 (held behind the live probe) is ignored by the same flush');
+
+	Time::HiRes::sleep(0.45);   # past ignore_duration
+
+	local $SIG{ALRM} = sub { die "GET3 hung: stale probe_sid was not cleared by the flush\n" };
+	alarm(3);
+	request_match($d, 'GET3 after the ignore window still probes and times out, rather than hanging',
+		[RT_GET, 594, $target, $ignport, ['1.3.6.1.2.1.1.5.0']],
+		[RT_GET|RT_REPLY, 594, [['1.3.6.1.2.1.1.5.0', ['timeout']]]]);
+	alarm(0);
+
+	request_match($d, 'engineid is still empty (discovery mode, not stranded)',
+		[RT_GETOPT, 595, $target, $ignport],
+		[RT_GETOPT|RT_REPLY, 595, {engineid => ''}]);
+	ok(kill(0, $d->pid), 'daemon is still alive');
+
+	$asilent->stop;
+}
+
 $d->stop;
 done_testing;

--- a/t/behavior-v3.t
+++ b/t/behavior-v3.t
@@ -318,5 +318,40 @@ for my $i (0 .. $#faults) {
 	$aslow->stop;
 }
 
+# empty-engineid reply during discovery: a bogus GET-RESPONSE carrying an empty
+# authoritative engineID matches the (empty) stored one and so bypasses the
+# mismatch branch. It must be ignored, never processed as a GET reply nor allowed
+# to strand the discovery state so future queries hang.
+{
+	my $abogus = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3, v3_empty_eid_reply => 1);
+	request_match($d, 'discovery setopt (empty-eid-reply agent)',
+		[RT_SETOPT, 580, $target, $abogus->port, {
+			version => 3, username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privpassword => $v3{priv_pass},
+			timeout => 100, retries => 2 }],
+		[RT_SETOPT|RT_REPLY, 580, T()]);
+	my $g0 = $d->request([RT_INFO, 581])->[2]{global};
+	request_match($d, 'bogus empty-eid reply is ignored; get times out',
+		[RT_GET, 582, $target, $abogus->port, ['1.3.6.1.2.1.1.5.0']],
+		[RT_GET|RT_REPLY, 582, [['1.3.6.1.2.1.1.5.0', ['timeout']]]]);
+	my $g1 = $d->request([RT_INFO, 583])->[2]{global};
+	is($g1->{v3_engineid_discoveries} - $g0->{v3_engineid_discoveries}, 0,
+		'the bogus empty-eid reply did not adopt an engine id');
+	ok($g1->{snmp_sends} - $g0->{snmp_sends} >= 2,
+		'the first get sent probe traffic (initial + retry)');
+	request_match($d, 'engineid still empty after the bogus reply',
+		[RT_GETOPT, 584, $target, $abogus->port],
+		[RT_GETOPT|RT_REPLY, 584, {engineid => ''}]);
+	# a second get must send a NEW probe, not hang forever on a stranded probe_sid
+	request_match($d, 'second get still probes (does not hang) and times out',
+		[RT_GET, 585, $target, $abogus->port, ['1.3.6.1.2.1.1.5.0']],
+		[RT_GET|RT_REPLY, 585, [['1.3.6.1.2.1.1.5.0', ['timeout']]]]);
+	my $g2 = $d->request([RT_INFO, 586])->[2]{global};
+	ok($g2->{snmp_sends} - $g1->{snmp_sends} >= 2,
+		'the second get sent a fresh probe (discovery state was not stranded)');
+	$abogus->stop;
+}
+
 $d->stop;
 done_testing;

--- a/t/behavior-v3.t
+++ b/t/behavior-v3.t
@@ -180,5 +180,47 @@ for my $i (0 .. $#faults) {
 	$asilent->stop;
 }
 
+# discovery happy path: probe, adopt, localize, release held queries
+{
+	my $ahappy = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3);
+	my $disc0 = $d->request([RT_INFO, 530])->[2]{global}{v3_engineid_discoveries};
+	request_match($d, 'discovery setopt (happy path)',
+		[RT_SETOPT, 531, $target, $ahappy->port, {
+			version => 3, username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privpassword => $v3{priv_pass} }],
+		[RT_SETOPT|RT_REPLY, 531, T()]);
+	request_match($d, 'v3 authPriv get succeeds via discovered engine id',
+		[RT_GET, 532, $target, $ahappy->port, ['1.3.6.1.2.1.1.5.0']],
+		[RT_GET|RT_REPLY, 532, [['1.3.6.1.2.1.1.5.0', $hostname]]]);
+	my $eid = pack 'H*', $v3{engine_id};
+	request_match($d, 'getopt shows discovered engine id and localized keys',
+		[RT_GETOPT, 533, $target, $ahappy->port],
+		[RT_GETOPT|RT_REPLY, 533, {
+			engineid => $v3{engine_id},
+			authkul  => unpack('H*', SQE::USM::password_to_kul('sha256', $v3{auth_pass}, $eid)),
+			privkul  => unpack('H*', SQE::USM::password_to_kul('sha256', $v3{priv_pass}, $eid)),
+		}]);
+	my $disc1 = $d->request([RT_INFO, 534])->[2]{global}{v3_engineid_discoveries};
+	is($disc1 - $disc0, 1, 'one engine id discovery counted');
+	$ahappy->stop;
+}
+
+# probe retry: first probe dropped, second one discovers
+{
+	my $adrop = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3, drop_first => 1);
+	request_match($d, 'discovery setopt (drop-first agent)',
+		[RT_SETOPT, 540, $target, $adrop->port, {
+			version => 3, username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privpassword => $v3{priv_pass},
+			timeout => 100, retries => 3 }],
+		[RT_SETOPT|RT_REPLY, 540, T()]);
+	request_match($d, 'discovery survives a dropped probe via normal retries',
+		[RT_GET, 541, $target, $adrop->port, ['1.3.6.1.2.1.1.5.0']],
+		[RT_GET|RT_REPLY, 541, [['1.3.6.1.2.1.1.5.0', $hostname]]]);
+	$adrop->stop;
+}
+
 $d->stop;
 done_testing;

--- a/t/behavior-v3.t
+++ b/t/behavior-v3.t
@@ -8,6 +8,7 @@ use lib "$FindBin::Bin/lib";
 use Test2::V0;
 use SQE::Test ':all';
 use SQE::FakeAgent;
+use SQE::USM;
 
 my $hostname = 'sqe-fake-v3';
 my @tree = (
@@ -91,6 +92,42 @@ for my $i (0 .. $#faults) {
 		[RT_GET|RT_REPLY, $base + 2, [['1.3.6.1.2.1.1.5.0', ['timeout']]]]);
 	my $after = $d->request([RT_INFO, $base + 3])->[2]{global}{bad_snmp_responses};
 	ok($after > $before, "$fault reply bumped bad_snmp_responses");
+}
+
+# ---- engine id discovery: setopt semantics ----
+
+# localized keys cannot be re-localized: engineid is mandatory with kuls
+{
+	my $eid = pack 'H*', $v3{engine_id};
+	my $authkul = unpack 'H*', SQE::USM::password_to_kul('sha256', $v3{auth_pass}, $eid);
+	my $privkul = unpack 'H*', SQE::USM::password_to_kul('sha256', $v3{priv_pass}, $eid);
+	request_match($d, 'authkul without engineid is a setopt error',
+		[RT_SETOPT, 500, $target, $port, {
+			version => 3, username => $v3{username},
+			authprotocol => 'sha256', authkul => $authkul,
+			privprotocol => 'aes128', privpassword => $v3{priv_pass} }],
+		[RT_SETOPT|RT_ERROR, 500, qr{engineid is required with authkul/privkul}]);
+	request_match($d, 'privkul without engineid is a setopt error',
+		[RT_SETOPT, 501, $target, $port, {
+			version => 3, username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privkul => $privkul }],
+		[RT_SETOPT|RT_ERROR, 501, qr{engineid is required with authkul/privkul}]);
+}
+
+# discovery mode: setopt without engineid + passwords is accepted, keys deferred
+{
+	my $adisc = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3);
+	request_match($d, 'setopt without engineid enters discovery mode',
+		[RT_SETOPT, 510, $target, $adisc->port, {
+			version => 3, username => $v3{username},
+			authprotocol => 'sha256', authpassword => $v3{auth_pass},
+			privprotocol => 'aes128', privpassword => $v3{priv_pass} }],
+		[RT_SETOPT|RT_REPLY, 510, {engineid => '', authkul => '', privkul => ''}]);
+	request_match($d, 'getopt before first query: engineid and kuls empty',
+		[RT_GETOPT, 511, $target, $adisc->port],
+		[RT_GETOPT|RT_REPLY, 511, {engineid => '', authkul => '', privkul => ''}]);
+	$adisc->stop;
 }
 
 $d->stop;

--- a/t/fake_agent.t
+++ b/t/fake_agent.t
@@ -130,7 +130,6 @@ ok(defined $treply && length($treply) == int(length($expect_reply) / 2)
 $trunc->stop;
 
 # ---- v3 engine id dialect ----
-use SQE::USM;
 
 my %v3 = (
 	engine_id  => '80001f88047371656369',

--- a/t/fake_agent.t
+++ b/t/fake_agent.t
@@ -129,4 +129,78 @@ ok(defined $treply && length($treply) == int(length($expect_reply) / 2)
 	"truncate: reply is the first half of the valid reply");
 $trunc->stop;
 
+# ---- v3 engine id dialect ----
+use SQE::USM;
+
+my %v3 = (
+	engine_id  => '80001f88047371656369',
+	username   => 'sqetest',
+	auth_proto => 'sha256', auth_pass => 'sqeauthpass12',
+	priv_proto => 'aes128', priv_pass => 'sqeprivpass12',
+	boots => 7, time => 1234,
+);
+my $eid = pack 'H*', $v3{engine_id};
+
+sub build_probe {   # RFC 3414 discovery probe shape (noAuthNoPriv GET, no varbinds)
+	my ($mid, %over) = @_;
+	my $pdu = SQE::FakeAgent::_tlv(0xa0,
+		SQE::FakeAgent::_enc_uint(0x02, $mid)
+		. SQE::FakeAgent::_enc_uint(0x02, 0)
+		. SQE::FakeAgent::_enc_uint(0x02, 0)
+		. SQE::FakeAgent::_tlv(0x30, ''));
+	my $peid = $over{eid} // '';
+	return SQE::FakeAgent->_build_v3(
+		mid => $mid, flags => 0x04, boots => 0, time => 0,
+		authenticated => 0, encrypted => 0, privp => '',
+		eid => $peid, username => $over{username} // '',
+		scoped => SQE::FakeAgent->_scoped($peid, $pdu),
+	);
+}
+
+sub report_oid_of {   # -> (parsed envelope, pdu tag, first varbind OID)
+	my ($reply) = @_;
+	my $r = SQE::FakeAgent->_parse_v3($reply);
+	# spd is the content of a SEQUENCE (for unencrypted) or OCTET STRING (for encrypted)
+	# For REPORT which is noAuthNoPriv, it's unencrypted (SEQUENCE content)
+	my $scoped = SQE::FakeAgent::_tlv($r->{spd_tag}, $r->{spd});
+	my (undef, $seq) = SQE::FakeAgent::_get_tlv($scoped, 0);
+	my $bp = 0;
+	(undef, undef, $bp) = SQE::FakeAgent::_get_tlv($seq, $bp);   # ctxEngineID
+	(undef, undef, $bp) = SQE::FakeAgent::_get_tlv($seq, $bp);   # ctxName
+	(my $ptag, my $pdu, $bp) = SQE::FakeAgent::_get_tlv($seq, $bp);
+	my $pp = 0;
+	(undef, undef, $pp) = SQE::FakeAgent::_get_tlv($pdu, $pp);   # request-id
+	(undef, undef, $pp) = SQE::FakeAgent::_get_tlv($pdu, $pp);   # error-status
+	(undef, undef, $pp) = SQE::FakeAgent::_get_tlv($pdu, $pp);   # error-index
+	(undef, my $vbl, $pp) = SQE::FakeAgent::_get_tlv($pdu, $pp);
+	(undef, my $vb) = SQE::FakeAgent::_get_tlv($vbl, 0);
+	(undef, my $oid_c) = SQE::FakeAgent::_get_tlv($vb, 0);
+	return ($r, $ptag, SQE::FakeAgent::_dec_oid($oid_c));
+}
+
+my $v3agent = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3);
+
+# discovery probe (empty engine id) draws an unknown-engine REPORT with the real engine id
+my ($r, $ptag, $roid) = report_oid_of(udp_exchange($v3agent->port, build_probe(101)));
+is($ptag, 0xa8, 'probe reply is a REPORT');
+is($roid, '1.3.6.1.6.3.15.1.1.4.0', 'probe draws usmStatsUnknownEngineIDs');
+is(unpack('H*', $r->{eid}), $v3{engine_id}, 'REPORT carries the agent engine id');
+is($r->{boots}, 7, 'REPORT carries agent boots');
+is($r->{time}, 1234, 'REPORT carries agent time');
+is($r->{flags} & 0x03, 0, 'REPORT is noAuthNoPriv');
+
+# engine id is checked before the username
+($r, $ptag, $roid) = report_oid_of(udp_exchange($v3agent->port,
+	build_probe(102, eid => $eid . "\x01", username => 'nosuchuser')));
+is($roid, '1.3.6.1.6.3.15.1.1.4.0',
+	'wrong engine id + wrong user -> unknown-engine, not unknown-user');
+
+my $chosen = $v3agent->port;
+$v3agent->stop;
+
+# fixed-port spawn (device-swap scenarios respawn on the same port)
+my $fixed = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3, port => $chosen);
+is($fixed->port, $chosen, 'spawn honors a fixed port');
+$fixed->stop;
+
 done_testing;

--- a/t/lib/SQE/FakeAgent.pm
+++ b/t/lib/SQE/FakeAgent.pm
@@ -51,7 +51,7 @@ sub spawn {
 	if (!$pid) {
 		close $rd;
 		my $sock = IO::Socket::INET->new(LocalAddr => '127.0.0.1',
-			LocalPort => 0, Proto => 'udp') or POSIX::_exit(1);
+			LocalPort => $opt{port} // 0, Proto => 'udp') or POSIX::_exit(1);
 		print $wr $sock->sockport, "\n";
 		close $wr;
 		$self->_serve($sock);
@@ -439,6 +439,12 @@ sub _handle_v3 {
 	return undef if $self->{v3_never_sync};
 
 	my $r = $self->_parse_v3($self->{_last_pkt});
+
+	# engine id must match, else send unknown-engine report (noAuth);
+	# an empty engine id is the RFC 3414 discovery probe
+	if ($r->{eid} ne $s->{eid}) {
+		return $self->_v3_report($r, 'unknown_engine');
+	}
 
 	# username must match, else send unknown-user report (noAuth)
 	if ($r->{user} ne $s->{username}) {

--- a/t/lib/SQE/FakeAgent.pm
+++ b/t/lib/SQE/FakeAgent.pm
@@ -32,6 +32,7 @@ sub spawn {
 		v3_never_sync  => $opt{v3_never_sync} // 0,
 		v3_report      => $opt{v3_report}     // '',
 		v3_reply_fault => $opt{v3_reply_fault} // '',
+		v3_empty_eid_reply => $opt{v3_empty_eid_reply} // 0,
 	}, $class;
 	if (my $v = $self->{v3}) {
 		my $eid = pack('H*', $v->{engine_id});
@@ -440,6 +441,10 @@ sub _handle_v3 {
 
 	my $r = $self->_parse_v3($self->{_last_pkt});
 
+	# misbehavior: answer any v3 request with a normal-looking GET-RESPONSE that
+	# carries an EMPTY authoritative engineID, noAuthNoPriv, the agent's username
+	return $self->_v3_empty_eid_reply($r) if $self->{v3_empty_eid_reply};
+
 	# engine id must match, else send unknown-engine report (noAuth);
 	# an empty engine id is the RFC 3414 discovery probe
 	if ($r->{eid} ne $s->{eid}) {
@@ -517,6 +522,23 @@ sub _handle_v3 {
 		eid => $eid, username => $user, auth_kul => $auth_kul, auth_proto => $s->{auth_proto},
 	);
 	return $reply;
+}
+
+# Build a noAuthNoPriv GET-RESPONSE with an empty authoritative engineID and the
+# agent's username (empty varbind list). Simulates a broken/hostile agent whose
+# reply, during discovery (stored engineID also empty), bypasses the client's
+# engine-id mismatch handling.
+sub _v3_empty_eid_reply {
+	my ($self, $r) = @_;
+	my $s = $self->{v3set};
+	my $resp_pdu = _tlv(0xa2,
+		_enc_uint(0x02, $r->{mid}) . _enc_uint(0x02, 0) . _enc_uint(0x02, 0)
+		. _tlv(0x30, ''));
+	my $scoped = $self->_scoped('', $resp_pdu);
+	return $self->_build_v3(
+		mid => $r->{mid}, flags => 0x00, boots => $s->{boots}, time => $s->{time},
+		authenticated => 0, encrypted => 0, scoped => $scoped, privp => '',
+		eid => '', username => $s->{username});
 }
 
 # Build a noAuthNoPriv report carrying $type; carries the agent's boots/time so

--- a/t/real-snmpd.t
+++ b/t/real-snmpd.t
@@ -53,6 +53,21 @@ if ($user && $engineid) {
 	request_match($d, "v3 get sysName",
 		[RT_GET, 201, $host, $port, ["1.3.6.1.2.1.1.5.0"]],
 		[RT_GET|RT_REPLY, 201, [["1.3.6.1.2.1.1.5.0", match qr/./]]]);
+
+	# engine id discovery: same credentials with engineid omitted; the env's
+	# engine id is the known-right answer, so this cross-checks discovery
+	# against a real net-snmp agent
+	my %v3d = %v3;
+	delete $v3d{engineid};
+	request_match($d, "set v3 credentials (discovery)",
+		[RT_SETOPT, 210, $host, $port, \%v3d],
+		[RT_SETOPT|RT_REPLY, 210, {engineid => ''}]);
+	request_match($d, "v3 get sysName via discovered engine id",
+		[RT_GET, 211, $host, $port, ["1.3.6.1.2.1.1.5.0"]],
+		[RT_GET|RT_REPLY, 211, [["1.3.6.1.2.1.1.5.0", match qr/./]]]);
+	request_match($d, "discovered engine id matches the configured one",
+		[RT_GETOPT, 212, $host, $port],
+		[RT_GETOPT|RT_REPLY, 212, {engineid => lc $engineid}]);
 } elsif ($user) {
 	note "SQE_SNMPD_V3_USER set but SQE_SNMPD_V3_ENGINEID missing; v3 needs the agent's engine id, skipping v3 checks";
 } else {

--- a/t/test_ber.c
+++ b/t/test_ber.c
@@ -313,6 +313,20 @@ test_usm_stats_unknown_engine_ids_oid(void)
 }
 
 int
+test_ber_string_error(void)
+{
+	struct ber b = ber_string_error("hello");
+	int r = 1;
+
+	if (b.max_len != 7 || memcmp(b.buf, "\x90\x05hello", 7) != 0) {
+		tap_diag("ber_string_error: unexpected encoding");
+		r = 0;
+	}
+	free(b.buf);
+	return r;
+}
+
+int
 test_v2c_getbulk_packet(int max_repetitions, const char *mrep_tlv)
 {
 	struct packet_builder pb;
@@ -456,6 +470,7 @@ main(void)
 	ok(test_v3_header_encoding(), "v3_header_encoding");
 	ok(test_v3_discovery_packet(), "v3_discovery_packet");
 	ok(test_usm_stats_unknown_engine_ids_oid(), "usmStatsUnknownEngineIDs oid");
+	ok(test_ber_string_error(), "ber_string_error");
 	ok(test_v2c_getbulk_packet(100, "\x02\x01\x64"), "v2c_getbulk_packet max_repetitions=100");
 	ok(test_v2c_getbulk_packet(200, "\x02\x01\x7f"), "v2c_getbulk_packet max_repetitions=200");
 

--- a/t/test_ber.c
+++ b/t/test_ber.c
@@ -250,6 +250,69 @@ test_v3_header_encoding(void)
 }
 
 int
+test_v3_discovery_packet(void)
+{
+	static unsigned char expected[] = {
+		0x30,0x3d,                          /* message SEQUENCE */
+		0x02,0x01,0x03,                     /* version 3 */
+		0x30,0x10,                          /* msgGlobalData */
+		0x02,0x04,0x01,0x02,0x03,0x04,      /* msgID */
+		0x02,0x02,0x05,0xc0,                /* msgMaxSize 1472 */
+		0x04,0x01,0x04,                     /* msgFlags: reportable */
+		0x02,0x01,0x03,                     /* msgSecurityModel USM */
+		0x04,0x10,                          /* msgSecurityParameters */
+		0x30,0x0e,
+		0x04,0x00,                          /* engine id "" */
+		0x02,0x01,0x00,                     /* boots 0 */
+		0x02,0x01,0x00,                     /* time 0 */
+		0x04,0x00,                          /* username "" */
+		0x04,0x00,                          /* auth params "" */
+		0x04,0x00,                          /* priv params "" */
+		0x30,0x14,                          /* plaintext scoped PDU */
+		0x04,0x00,                          /* context engine id "" */
+		0x04,0x00,                          /* context name "" */
+		0xa0,0x0e,                          /* GetRequest PDU */
+		0x02,0x04,0x01,0x02,0x03,0x04,      /* request-id */
+		0x02,0x01,0x00,                     /* error-status */
+		0x02,0x01,0x00,                     /* error-index */
+		0x30,0x00,                          /* empty varbind list */
+	};
+	struct ber pkt;
+	int r = 1;
+
+	if (build_v3_discovery_packet(0x01020304, 1472, &pkt) < 0) {
+		tap_diag("build_v3_discovery_packet failed");
+		return 0;
+	}
+	if (pkt.len != (int)sizeof(expected)) {
+		tap_diag("discovery packet length %d != %d", pkt.len, (int)sizeof(expected));
+		r = 0;
+	} else if (memcmp(pkt.buf, expected, sizeof(expected)) != 0) {
+		tap_diag("discovery packet bytes differ");
+		r = 0;
+	}
+	free(pkt.buf);
+	return r;
+}
+
+int
+test_usm_stats_unknown_engine_ids_oid(void)
+{
+	char tmp_buf[64];
+	struct ber e = ber_init(tmp_buf, 64);
+
+	if (populate_well_known_oids() < 0) {
+		tap_diag("populate_well_known_oids failed");
+		return 0;
+	}
+	if (encode_string_oid("1.3.6.1.6.3.15.1.1.4.0", -1, &e) < 0) {
+		tap_diag("encode_string_oid failed");
+		return 0;
+	}
+	return ber_equal(&e, &usmStatsUnknownEngineIDs);
+}
+
+int
 test_v2c_getbulk_packet(int max_repetitions, const char *mrep_tlv)
 {
 	struct packet_builder pb;
@@ -391,6 +454,8 @@ main(void)
 	ok(test_next_sid_from(0, 0x01000001), "next_sid_from 0");
 
 	ok(test_v3_header_encoding(), "v3_header_encoding");
+	ok(test_v3_discovery_packet(), "v3_discovery_packet");
+	ok(test_usm_stats_unknown_engine_ids_oid(), "usmStatsUnknownEngineIDs oid");
 	ok(test_v2c_getbulk_packet(100, "\x02\x01\x64"), "v2c_getbulk_packet max_repetitions=100");
 	ok(test_v2c_getbulk_packet(200, "\x02\x01\x7f"), "v2c_getbulk_packet max_repetitions=200");
 

--- a/t/test_ber.c
+++ b/t/test_ber.c
@@ -322,6 +322,10 @@ test_ber_string_error(void)
 		tap_diag("ber_string_error: unexpected encoding");
 		r = 0;
 	}
+	if (b.len != 0) {
+		tap_diag("ber_string_error: result must be rewound (len == 0)");
+		r = 0;
+	}
 	free(b.buf);
 	return r;
 }


### PR DESCRIPTION
Adds RFC 3414 engine ID discovery, opt-in by omitting `engineid` in SETOPT:
the engine probes the agent on first use, adopts the reported engine ID,
localizes the configured passwords, and treats it as pinned from then on.
Pinned mode is unchanged byte-for-byte and remains the right choice when
credentials are shared across a fleet — the manual documents the tradeoff.

Also:
- authkul/privkul without engineid is now an immediate setopt error
- engine ID mismatch REPORTs fail the request fast with
  ["engine-id-mismatch: <hex>"] instead of a silent timeout
- new global INFO counters v3_engineid_discoveries / v3_engineid_mismatches
- SETOPT with any SNMPv3 option rebuilds the whole v3 configuration from
  that request; re-setopt without engineid triggers re-discovery

Test plan:
- [x] discovery, mismatch, re-discovery, and probe-lifecycle scenarios in
      t/behavior-v3.t; byte-exact probe packet in t/ber.t
- [x] cross-checked against real net-snmp (t/real-snmpd.t)
- [x] scan-build clean, full suite green