### PR TITLE
fix: v3 setopt hexstring validation and settings leak on disconnect

### DIFF
--- a/.changes/unreleased/Fixed-20260712-093430.yaml
+++ b/.changes/unreleased/Fixed-20260712-093430.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'setopt: reject malformed engineid, authkul, and privkul hex strings'
+time: 2026-07-12T09:34:30.337334+02:00

--- a/.changes/unreleased/Fixed-20260712-093435.yaml
+++ b/.changes/unreleased/Fixed-20260712-093435.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: fix SNMPv3 settings memory leak on client disconnect
+time: 2026-07-12T09:34:35.882168+02:00

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ t/test_v3
 t/test_sid_info
 t/test_log
 t/test_throttle
+t/test_cri
 t/*.dSYM/
 *.o
 .*.swp

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OPTIMIZE=	-O3 -g
 INCPATH=	-I. -I/usr/local/include -I/opt/local/include -I/opt/homebrew/include
 LIBPATH=	-L/usr/local/lib -L/opt/local/lib -L/opt/homebrew/lib
 CFLAGS=	-Wall -Wno-unused-function -Wno-deprecated-declarations -Werror $(OPTIMIZE) $(INCPATH)
-TESTBIN=	t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log t/test_throttle
+TESTBIN=	t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log t/test_throttle t/test_cri
 
 PREFIX?=	/usr/local
 BINDIR?=	$(PREFIX)/bin
@@ -29,7 +29,7 @@ STDOBJ=event_loop.o carp.o client_input.o client_listen.o opts.o util.o destinat
 STDLINK=$(STDOBJ) $(LIBPATH) $(LIBS)
 
 clean:
-	rm -f *.o snmp-query-engine t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log t/test_throttle *.core core
+	rm -f *.o snmp-query-engine t/test_ber t/test_msgpack t/test_v3 t/test_sid_info t/test_log t/test_throttle t/test_cri *.core core
 	rm -rf t/*.dSYM *.dSYM
 
 install: snmp-query-engine
@@ -133,6 +133,9 @@ t/test_v3: t/test_v3.c t/tap.h $(STDOBJ)
 
 t/test_sid_info: t/test_sid_info.c t/tap.h $(STDOBJ)
 	$(CC) $(CFLAGS) -o t/test_sid_info t/test_sid_info.c $(STDLINK)
+
+t/test_cri: t/test_cri.c t/tap.h $(STDOBJ)
+	$(CC) $(CFLAGS) -o t/test_cri t/test_cri.c $(STDLINK)
 
 test: snmp-query-engine $(TESTBIN)
 	prove t/

--- a/client_requests_info.c
+++ b/client_requests_info.c
@@ -124,6 +124,7 @@ free_client_request_info(struct client_requests_info *cri)
 	}
 	JLFA(rc, cri->cid_info);
 	JLD(rc, cri->dest->client_requests_info, cri->fd);
+	free(cri->v3);
 	free(cri);
 	return 1;
 }

--- a/request_setopt.c
+++ b/request_setopt.c
@@ -90,6 +90,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 	int seen_privpassword = 0;
 	int seen_privkul = 0;
 	int seen_engineid = 0;
+	ssize_t hexlen;
 
 	if (o->via.array.size != 5)
 		return error_reply(si, RT_SETOPT|RT_ERROR, cid, "bad request length");
@@ -201,9 +202,10 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 				bzero(&d.ignore_until, sizeof(cri->dest->ignore_until));
 			break;
 		case OPT_engineid:
-			v3.engine_id_len = object_hexstring_to_buffer(v, v3.engine_id, V3O_ENGINE_ID_MAXLEN);
-			if (v3.engine_id_len < 0)
+			hexlen = object_hexstring_to_buffer(v, v3.engine_id, V3O_ENGINE_ID_MAXLEN);
+			if (hexlen < 0)
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid engineid hexstring");
+			v3.engine_id_len = hexlen;
 			need_v3 = 1;
 			seen_engineid = 1;
 			break;
@@ -241,9 +243,10 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 			need_v3 = 1;
 			break;
 		case OPT_authkul:
-			v3.authkul_len = object_hexstring_to_buffer(v, v3.authkul, V3O_AUTHKUL_MAXSIZE);
-			if (v3.authkul_len < 0)
+			hexlen = object_hexstring_to_buffer(v, v3.authkul, V3O_AUTHKUL_MAXSIZE);
+			if (hexlen < 0)
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid authkul hexstring");
+			v3.authkul_len = hexlen;
 			seen_authkul = 1;
 			v3.authpass[0] = 0;
 			need_v3 = 1;
@@ -280,9 +283,10 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 			need_v3 = 1;
 			break;
 		case OPT_privkul:
-			v3.privkul_len = object_hexstring_to_buffer(v, v3.privkul, V3O_PRIVKUL_MAXSIZE);
-			if (v3.privkul_len < 0)
+			hexlen = object_hexstring_to_buffer(v, v3.privkul, V3O_PRIVKUL_MAXSIZE);
+			if (hexlen < 0)
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid privkul hexstring");
+			v3.privkul_len = hexlen;
 			seen_privkul = 1;
 			v3.privpass[0] = 0;
 			need_v3 = 1;

--- a/sqe.h
+++ b/sqe.h
@@ -552,7 +552,7 @@ extern int feed_client_unpacker(struct client_connection *c, const uint8_t *buf,
 /* util.c */
 extern char *object_strdup(msgpack_object *o);
 extern char *object2string(msgpack_object *o, char s[], int bufsize);
-extern size_t object_hexstring_to_buffer(msgpack_object *o, uint8_t *buf, size_t bufsize);
+extern ssize_t object_hexstring_to_buffer(msgpack_object *o, uint8_t *buf, size_t bufsize);
 extern int object_string_eq(msgpack_object *o, char *s);
 extern int object2ip(msgpack_object *o, struct in_addr *ip); /* 1 = success, 0 = failure */
 extern unsigned next_sid(void);

--- a/t/cri.t
+++ b/t/cri.t
@@ -1,0 +1,29 @@
+#! /usr/bin/perl
+# ABOUTME: Runs t/test_cri under a leak detector (macOS leaks or LeakSanitizer)
+# ABOUTME: to prove free_client_request_info() releases everything the cri owns.
+use strict;
+use warnings;
+use FindBin;
+use Test2::V0;
+
+my $bin = "$FindBin::Bin/test_cri";
+skip_all "$bin is not built (run make first)" unless -x $bin;
+
+my $plain = `$bin 2>&1`;
+is($? >> 8, 0, "test_cri scenario passes") or diag($plain);
+
+if ($^O eq 'darwin' && grep { -x "$_/leaks" } split /:/, $ENV{PATH}) {
+	my $out = `leaks --atExit -- $bin 2>&1`;
+	like($out, qr/\b0 leaks for 0 total leaked bytes/, "no leaks (macOS leaks)")
+		or diag($out);
+} elsif (`nm $bin 2>/dev/null` =~ /__asan/) {
+	local $ENV{ASAN_OPTIONS} = "detect_leaks=1";
+	my $out = `$bin 2>&1`;
+	my $rc = $? >> 8;
+	ok($rc == 0 && $out !~ /LeakSanitizer/, "no leaks (LeakSanitizer)")
+		or diag($out);
+} else {
+	note "no leak detector available on this platform; leak check skipped";
+}
+
+done_testing;

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -133,6 +133,13 @@ request_match($d, "setopt bad max repetitions 2", [RT_SETOPT,2221,"127.0.0.1",16
 request_match($d, "setopt bad max repetitions 3", [RT_SETOPT,2222,"127.0.0.1",161,{max_repetitions=>256}], [RT_SETOPT|RT_ERROR,2222,qr/invalid max repetitions/]);
 request_match($d, "setopt bad max repetitions 4", [RT_SETOPT,2223,"127.0.0.1",161,{max_repetitions=>128}], [RT_SETOPT|RT_ERROR,2223,qr/invalid max repetitions/]);
 request_match($d, "gettable bad max repetitions", [RT_GETTABLE,2224,"127.0.0.1",161,"1.3.6.1.2.1.1.9.1.2",128], [RT_GETTABLE|RT_ERROR,2224,qr/bad max repetitions/]);
+request_match($d, "setopt bad engineid 1", [RT_SETOPT,2230,"127.0.0.1",161,{engineid=>"zz"}], [RT_SETOPT|RT_ERROR,2230,qr/invalid engineid hexstring/]);
+request_match($d, "setopt bad engineid 2", [RT_SETOPT,2231,"127.0.0.1",161,{engineid=>"800"}], [RT_SETOPT|RT_ERROR,2231,qr/invalid engineid hexstring/]);
+request_match($d, "setopt bad engineid 3", [RT_SETOPT,2232,"127.0.0.1",161,{engineid=>"ab" x 65}], [RT_SETOPT|RT_ERROR,2232,qr/invalid engineid hexstring/]);
+request_match($d, "setopt bad authkul 1", [RT_SETOPT,2233,"127.0.0.1",161,{authkul=>"zz"}], [RT_SETOPT|RT_ERROR,2233,qr/invalid authkul hexstring/]);
+request_match($d, "setopt bad authkul 2", [RT_SETOPT,2234,"127.0.0.1",161,{authkul=>"abc"}], [RT_SETOPT|RT_ERROR,2234,qr/invalid authkul hexstring/]);
+request_match($d, "setopt bad privkul 1", [RT_SETOPT,2235,"127.0.0.1",161,{privkul=>"zz"}], [RT_SETOPT|RT_ERROR,2235,qr/invalid privkul hexstring/]);
+request_match($d, "setopt bad privkul 2", [RT_SETOPT,2236,"127.0.0.1",161,{privkul=>"ab" x 65}], [RT_SETOPT|RT_ERROR,2236,qr/invalid privkul hexstring/]);
 request_match($d, "defaults unchanged", [RT_SETOPT,2023,"127.0.0.1",161, {}], [RT_SETOPT|RT_REPLY,2023,
 	{ip=>"127.0.0.1", port=>161, community=>"public", version=>2, max_packets => 3, max_req_size => 1400, timeout => 2000, retries => 3, min_interval => 10, max_repetitions => 10, }]);
 request_match($d, "change timeout", [RT_SETOPT,2024,"127.0.0.1",161, {timeout=>1500}], [RT_SETOPT|RT_REPLY,2024,

--- a/t/test_cri.c
+++ b/t/test_cri.c
@@ -27,6 +27,8 @@ main(void)
 
 	cri = get_client_requests_info(&ip, 161, &sock);
 	ok(cri != NULL, "get_client_requests_info creates a cri");
+	if (!cri)
+		croak(2, "get_client_requests_info returned NULL");
 
 	/* what a v3 setopt does (request_setopt.c) */
 	cri->v3 = malloc(sizeof(struct snmpv3info));

--- a/t/test_cri.c
+++ b/t/test_cri.c
@@ -1,0 +1,40 @@
+/*
+ * Part of `snmp-query-engine`.
+ *
+ * Copyright 2026, Anton Berezin <tobez@tobez.org>
+ * Modified BSD license.
+ * (See LICENSE file in the distribution.)
+ *
+ */
+/* ABOUTME: Exercises the client_requests_info lifecycle: a cri carrying
+ * ABOUTME: SNMPv3 settings is created and torn down; t/cri.t leak-checks it. */
+#include "sqe.h"
+#include "tap.h"
+
+int
+main(void)
+{
+	struct socket_info sock;
+	struct in_addr ip;
+	struct client_requests_info *cri;
+
+	bzero(&sock, sizeof sock);
+	sock.fd = 7;
+	TAILQ_INIT(&sock.send_bufs);
+
+	if (!inet_aton("127.0.0.1", &ip))
+		croak(2, "inet_aton");
+
+	cri = get_client_requests_info(&ip, 161, &sock);
+	ok(cri != NULL, "get_client_requests_info creates a cri");
+
+	/* what a v3 setopt does (request_setopt.c) */
+	cri->v3 = malloc(sizeof(struct snmpv3info));
+	if (!cri->v3)
+		croak(2, "malloc(v3)");
+	bzero(cri->v3, sizeof(struct snmpv3info));
+
+	ok(free_client_request_info(cri) == 1, "free_client_request_info succeeds");
+
+	return tap_done();
+}

--- a/util.c
+++ b/util.c
@@ -59,7 +59,7 @@ object2string(msgpack_object *o, char s[], int bufsize)
 	return s;
 }
 
-size_t
+ssize_t
 object_hexstring_to_buffer(msgpack_object *o, uint8_t *buf, size_t bufsize)
 {
 	const char *s = NULL;


### PR DESCRIPTION
## Summary

**Hexstring validation.** `object_hexstring_to_buffer()` returned `size_t` but
signaled errors with `-1`, so the setopt call sites' `unsigned < 0` checks were
tautologically false: malformed `engineid`/`authkul`/`privkul` hex strings
passed validation with length `UINT_MAX`, which downstream consumers read as a
real length. Now returns `ssize_t`, checked via a signed `hexlen` at all three
sites; setopt replies `invalid <option> hexstring` on non-hex input, odd digit
count, or overflow.

**SNMPv3 settings leak.** `free_client_request_info()` never freed the
malloc'd `cri->v3`, leaking one `struct snmpv3info` per disconnect of a
v3-configured client. Now freed with the cri.

**Leak-checked test tier.** New `t/test_cri.c` + `t/cri.t` rerun the cri
lifecycle under macOS `leaks` or LeakSanitizer (skipped where neither exists).

## Test plan

- [x] 7 new protocol tests: non-hex, odd digit count, overflow (failing before the fix)
- [x] t/cri.t: 1 leak / 512 bytes before the fix, 0 after
- [x] `make test` from clean: 473/473, output pristine
- [x] scan-build: No bugs found.