### PR TITLE
refactor: move BER INTEGER sign-extension into decode_integer

### DIFF
--- a/ber.c
+++ b/ber.c
@@ -736,7 +736,9 @@ decode_integer(struct ber *e, int l, unsigned *value)
         EXTEND(l);
         return 0;
     }
-    *value = 0;
+    /* BER INTEGER is signed two's-complement: a 1-3 byte encoding whose
+     * first content byte has the top bit set is a negative number */
+    *value = (l >= 1 && l <= 3 && (e->b[0] & 0x80)) ? 0xffffffffu : 0;
     while (l) {
         *value = *value << 8 | e->b[0];
         EXTEND(1);

--- a/ber.c
+++ b/ber.c
@@ -663,7 +663,7 @@ decode_ipv4_address(struct ber *e, int l, struct in_addr *ip)
         }
         l = (int)len;
     }
-    if (decode_integer(e, l, &int_ip) < 0)
+    if (decode_unsigned(e, l, &int_ip) < 0)
         return -1;
     ip->s_addr = htonl(int_ip);
     return 0;
@@ -731,6 +731,26 @@ decode_integer(struct ber *e, int l, unsigned *value)
         }
         l = (int)len;
     }
+    SPACECHECK(l);
+    if (!value) {
+        EXTEND(l);
+        return 0;
+    }
+    *value = 0;
+    while (l) {
+        *value = *value << 8 | e->b[0];
+        EXTEND(1);
+        l--;
+    }
+    return 0;
+}
+
+/* Raw big-endian accumulator without sign-extension, for content that is
+ * unsigned by definition: Counter32, Gauge32/Unsigned32, IpAddress bytes.
+ * The content length must already be known; there is no tag-reading path. */
+int
+decode_unsigned(struct ber *e, int l, unsigned *value)
+{
     SPACECHECK(l);
     if (!value) {
         EXTEND(l);

--- a/request_common.c
+++ b/request_common.c
@@ -200,16 +200,7 @@ msgpack_pack_ber(struct msgpack_packer *pk, struct ber value)
 	switch (t) {
 	case AT_INTEGER:
 		if (decode_integer(&value, len, &u32) < 0)	goto decode_error;
-		/* XXX quick fix, but should be correct! */
-		if (len == 1 && (u32 & 0x80)) {
-			msgpack_pack_int64(pk, ((int32_t)(uint32_t)u32) - 0x100);
-		} else if (len == 2 && (u32 & 0x8000)) {
-			msgpack_pack_int64(pk, ((int32_t)(uint32_t)u32) - 0x10000);
-		} else if (len == 3 && (u32 & 0x800000)) {
-			msgpack_pack_int64(pk, ((int32_t)(uint32_t)u32) - 0x1000000);
-		} else {
-			msgpack_pack_int64(pk, (int32_t)(uint32_t)u32);
-		}
+		msgpack_pack_int64(pk, (int32_t)u32);
 		break;
 	case AT_COUNTER:
 	case AT_UNSIGNED:

--- a/request_common.c
+++ b/request_common.c
@@ -199,23 +199,22 @@ msgpack_pack_ber(struct msgpack_packer *pk, struct ber value)
 		t = VAL_DECODE_ERROR;
 	switch (t) {
 	case AT_INTEGER:
+		if (decode_integer(&value, len, &u32) < 0)	goto decode_error;
+		/* XXX quick fix, but should be correct! */
+		if (len == 1 && (u32 & 0x80)) {
+			msgpack_pack_int64(pk, ((int32_t)(uint32_t)u32) - 0x100);
+		} else if (len == 2 && (u32 & 0x8000)) {
+			msgpack_pack_int64(pk, ((int32_t)(uint32_t)u32) - 0x10000);
+		} else if (len == 3 && (u32 & 0x800000)) {
+			msgpack_pack_int64(pk, ((int32_t)(uint32_t)u32) - 0x1000000);
+		} else {
+			msgpack_pack_int64(pk, (int32_t)(uint32_t)u32);
+		}
+		break;
 	case AT_COUNTER:
 	case AT_UNSIGNED:
-		if (decode_integer(&value, len, &u32) < 0)	goto decode_error;
-		if (t == AT_INTEGER) {
-			/* XXX quick fix, but should be correct! */
-			if (len == 1 && (u32 & 0x80)) {
-				msgpack_pack_int64(pk, ((int32_t)(uint32_t)u32) - 0x100);
-			} else if (len == 2 && (u32 & 0x8000)) {
-				msgpack_pack_int64(pk, ((int32_t)(uint32_t)u32) - 0x10000);
-			} else if (len == 3 && (u32 & 0x800000)) {
-				msgpack_pack_int64(pk, ((int32_t)(uint32_t)u32) - 0x1000000);
-			} else {
-				msgpack_pack_int64(pk, (int32_t)(uint32_t)u32);
-			}
-		} else {
-			msgpack_pack_uint64(pk, u32);
-		}
+		if (decode_unsigned(&value, len, &u32) < 0)	goto decode_error;
+		msgpack_pack_uint64(pk, u32);
 		break;
 	case AT_STRING:
 		msgpack_pack_bin(pk, len);

--- a/sqe.h
+++ b/sqe.h
@@ -464,6 +464,7 @@ extern int encode_store_length(struct ber *e, unsigned char *s);
 
 extern int decode_type_len(struct ber *e, unsigned char *type, unsigned *len);
 extern int decode_integer(struct ber *e, int int_len, unsigned *value);
+extern int decode_unsigned(struct ber *e, int int_len, unsigned *value);
 extern int decode_string(struct ber *e, unsigned char *s, unsigned s_size, unsigned *s_len); // adds nul byte, needs space for it
 extern int decode_octets(struct ber *e, unsigned char *s, unsigned s_size, unsigned *s_len);  // does not add nul byte
 extern int decode_ipv4_address(struct ber *e, int l, struct in_addr *ip);

--- a/t/behavior.t
+++ b/t/behavior.t
@@ -221,6 +221,39 @@ request_match($d, "destinfo non-zero", [RT_DEST_INFO,6630,$target,$port], [RT_DE
 	$droppy->stop;
 }
 
+# --- negative INTEGER values ---
+# _enc_int byte-level pins: minimal two's-complement encodings
+is(SQE::FakeAgent::_enc_int(0x02, 0),          "\x02\x01\x00",             "_enc_int 0");
+is(SQE::FakeAgent::_enc_int(0x02, 127),        "\x02\x01\x7f",             "_enc_int 127");
+is(SQE::FakeAgent::_enc_int(0x02, 128),        "\x02\x02\x00\x80",         "_enc_int 128");
+is(SQE::FakeAgent::_enc_int(0x02, -1),         "\x02\x01\xff",             "_enc_int -1");
+is(SQE::FakeAgent::_enc_int(0x02, -5),         "\x02\x01\xfb",             "_enc_int -5");
+is(SQE::FakeAgent::_enc_int(0x02, -128),       "\x02\x01\x80",             "_enc_int -128");
+is(SQE::FakeAgent::_enc_int(0x02, -129),       "\x02\x02\xff\x7f",         "_enc_int -129");
+is(SQE::FakeAgent::_enc_int(0x02, -32768),     "\x02\x02\x80\x00",         "_enc_int -32768");
+is(SQE::FakeAgent::_enc_int(0x02, 2147483647), "\x02\x04\x7f\xff\xff\xff", "_enc_int INT32_MAX");
+
+{
+	my $neg = SQE::FakeAgent->spawn(tree => [
+		['1.3.6.1.2.1.99.1', int => -5],
+		['1.3.6.1.2.1.99.2', int => -129],
+		['1.3.6.1.2.1.99.3', int => -32768],
+		['1.3.6.1.2.1.99.4', int => -2147483648],
+		['1.3.6.1.2.1.99.5', int => 2147483647],
+	]);
+	my $nport = $neg->port;
+	request_match($d, "negative INTEGER values decode correctly",
+		[RT_GET, 7300, $target, $nport, ["1.3.6.1.2.1.99.1", "1.3.6.1.2.1.99.2", "1.3.6.1.2.1.99.3", "1.3.6.1.2.1.99.4", "1.3.6.1.2.1.99.5"]],
+		[RT_GET|RT_REPLY, 7300, [
+			["1.3.6.1.2.1.99.1", -5],
+			["1.3.6.1.2.1.99.2", -129],
+			["1.3.6.1.2.1.99.3", -32768],
+			["1.3.6.1.2.1.99.4", -2147483648],
+			["1.3.6.1.2.1.99.5", 2147483647],
+		]]);
+	$neg->stop;
+}
+
 $agent->stop;
 $d->stop;
 done_testing;

--- a/t/lib/SQE/FakeAgent.pm
+++ b/t/lib/SQE/FakeAgent.pm
@@ -119,7 +119,7 @@ sub _tlv {
 	return chr($tag) . _ber_len(length $content) . $content;
 }
 
-sub _enc_uint {   # unsigned integer-valued types (Counter, Gauge, TimeTicks)
+sub _enc_uint {   # unsigned integer-valued types (Counter, Gauge, TimeTicks, non-negative INTEGER header fields)
 	my ($tag, $n) = @_;
 	my @b;
 	do { unshift @b, $n & 0xff; $n >>= 8 } while ($n);

--- a/t/lib/SQE/FakeAgent.pm
+++ b/t/lib/SQE/FakeAgent.pm
@@ -119,11 +119,21 @@ sub _tlv {
 	return chr($tag) . _ber_len(length $content) . $content;
 }
 
-sub _enc_uint {   # unsigned integer-valued types (INTEGER >= 0, Counter, Gauge, TimeTicks)
+sub _enc_uint {   # unsigned integer-valued types (Counter, Gauge, TimeTicks)
 	my ($tag, $n) = @_;
 	my @b;
 	do { unshift @b, $n & 0xff; $n >>= 8 } while ($n);
 	unshift @b, 0 if $b[0] & 0x80;
+	return _tlv($tag, join '', map chr, @b);
+}
+
+sub _enc_int {   # signed INTEGER, minimal two's-complement encoding
+	my ($tag, $n) = @_;
+	my $l = 1;
+	$l++ while $n < -(2 ** (8*$l - 1)) || $n >= 2 ** (8*$l - 1);
+	$n += 2 ** (8 * $l) if $n < 0;
+	my @b;
+	unshift @b, ($n >> (8 * $_)) & 0xff for 0 .. $l - 1;
 	return _tlv($tag, join '', map chr, @b);
 }
 
@@ -140,7 +150,7 @@ sub _enc_oid_content {
 
 sub _enc_value {
 	my ($type, $v) = @_;
-	return _enc_uint(0x02, $v)                  if $type eq 'int';
+	return _enc_int(0x02, $v)                   if $type eq 'int';
 	return _tlv(0x04, $v)                       if $type eq 'str';
 	return _tlv(0x06, _enc_oid_content($v))     if $type eq 'oid';
 	return _enc_uint(0x41, $v)                  if $type eq 'counter';

--- a/t/test_ber.c
+++ b/t/test_ber.c
@@ -233,6 +233,26 @@ test_decode_unsigned_short(void)
 }
 
 int
+test_decode_integer(const char *tlv, int tlv_len, unsigned expected)
+{
+	unsigned char buf[16];
+	struct ber e;
+	unsigned got;
+
+	memcpy(buf, tlv, tlv_len);
+	e = ber_init(buf, tlv_len);
+	if (decode_integer(&e, -1, &got) < 0) {
+		tap_diag("decode_integer: unexpected failure");
+		return 0;
+	}
+	if (got != expected) {
+		tap_diag("decode_integer: got %#x, expected %#x", got, expected);
+		return 0;
+	}
+	return 1;
+}
+
+int
 test_next_sid_from(unsigned cur, unsigned expected)
 {
 	unsigned got;
@@ -521,6 +541,20 @@ main(void)
 	ok(test_decode_unsigned("\xff\xff\xff\xff", 4, 0xffffffffu), "decode_unsigned ff ff ff ff");
 	ok(test_decode_unsigned_skip(), "decode_unsigned NULL value skips content");
 	ok(test_decode_unsigned_short(), "decode_unsigned fails on short buffer");
+
+	ok(test_decode_integer("\x02\x01\x00", 3, 0), "decode_integer 0");
+	ok(test_decode_integer("\x02\x01\x7f", 3, 127), "decode_integer 127");
+	ok(test_decode_integer("\x02\x02\x00\x80", 4, 128), "decode_integer 128");
+	ok(test_decode_integer("\x02\x03\x00\xff\xe3", 5, 65507), "decode_integer 65507");
+	ok(test_decode_integer("\x02\x01\xff", 3, 0xffffffffu), "decode_integer -1");
+	ok(test_decode_integer("\x02\x01\x80", 3, 0xffffff80u), "decode_integer -128");
+	ok(test_decode_integer("\x02\x02\xff\x7f", 4, 0xffffff7fu), "decode_integer -129");
+	ok(test_decode_integer("\x02\x02\x80\x00", 4, 0xffff8000u), "decode_integer -32768");
+	ok(test_decode_integer("\x02\x03\x80\x00\x00", 5, 0xff800000u), "decode_integer -8388608");
+	ok(test_decode_integer("\x02\x04\xff\xff\xff\xff", 6, 0xffffffffu), "decode_integer 4-byte -1");
+	ok(test_decode_integer("\x02\x04\x80\x00\x00\x00", 6, 0x80000000u), "decode_integer INT32_MIN");
+	ok(test_decode_integer("\x02\x05\x00\xff\xff\xff\xff", 7, 0xffffffffu), "decode_integer 5-byte 0xffffffff");
+	ok(test_decode_integer("\x02\x00", 2, 0), "decode_integer zero-length content");
 
 	ok(test_next_sid_from(0x01000000, 0x01000001), "next_sid_from 0x01000000");
 	ok(test_next_sid_from(0x01ffffff, 0x02000000), "next_sid_from 0x01ffffff");

--- a/t/test_ber.c
+++ b/t/test_ber.c
@@ -182,6 +182,57 @@ test_encode_integer(unsigned value, int force_size, const char *res, int len)
 }
 
 int
+test_decode_unsigned(const char *content, int l, unsigned expected)
+{
+	unsigned char buf[16];
+	struct ber e;
+	unsigned got;
+
+	memcpy(buf, content, l);
+	e = ber_init(buf, l);
+	if (decode_unsigned(&e, l, &got) < 0) {
+		tap_diag("decode_unsigned: unexpected failure");
+		return 0;
+	}
+	if (got != expected) {
+		tap_diag("decode_unsigned: got %#x, expected %#x", got, expected);
+		return 0;
+	}
+	return 1;
+}
+
+int
+test_decode_unsigned_skip(void)
+{
+	unsigned char buf[4] = { 0xde, 0xad, 0xbe, 0xef };
+	struct ber e = ber_init(buf, 4);
+
+	if (decode_unsigned(&e, 4, NULL) < 0) {
+		tap_diag("decode_unsigned skip: unexpected failure");
+		return 0;
+	}
+	if (e.len != 4) {
+		tap_diag("decode_unsigned skip: cursor not advanced (len %d)", e.len);
+		return 0;
+	}
+	return 1;
+}
+
+int
+test_decode_unsigned_short(void)
+{
+	unsigned char buf[1] = { 0xff };
+	struct ber e = ber_init(buf, 1);
+	unsigned got;
+
+	if (decode_unsigned(&e, 2, &got) == 0) {
+		tap_diag("decode_unsigned: unexpected success past buffer end");
+		return 0;
+	}
+	return 1;
+}
+
+int
 test_next_sid_from(unsigned cur, unsigned expected)
 {
 	unsigned got;
@@ -463,6 +514,13 @@ main(void)
 	ok(test_encode_integer(0xffffffffu, 0, "\x02\x05\x00\xff\xff\xff\xff", 7), "encode_integer 0xffffffff");
 	ok(test_encode_integer(6789012, 4, "\x02\x04\x00\x67\x97\x94", 6), "encode_integer 6789012 force_size=4");
 	ok(test_encode_integer(0x01020304, 4, "\x02\x04\x01\x02\x03\x04", 6), "encode_integer 0x01020304 force_size=4");
+
+	ok(test_decode_unsigned("\x80", 1, 128), "decode_unsigned 80 stays 128 (no sign-extension)");
+	ok(test_decode_unsigned("\x00\x80", 2, 128), "decode_unsigned 00 80");
+	ok(test_decode_unsigned("\xff\xff", 2, 65535), "decode_unsigned ff ff");
+	ok(test_decode_unsigned("\xff\xff\xff\xff", 4, 0xffffffffu), "decode_unsigned ff ff ff ff");
+	ok(test_decode_unsigned_skip(), "decode_unsigned NULL value skips content");
+	ok(test_decode_unsigned_short(), "decode_unsigned fails on short buffer");
 
 	ok(test_next_sid_from(0x01000000, 0x01000001), "next_sid_from 0x01000000");
 	ok(test_next_sid_from(0x01ffffff, 0x02000000), "next_sid_from 0x01ffffff");


### PR DESCRIPTION
BER INTEGER is signed two's-complement, but decode_integer() was a raw
unsigned accumulator; the sign knowledge lived in an "XXX quick fix" block
in msgpack_pack_ber() that special-cased 1-3 byte encodings (4-byte ones
worked only by accident of an int32_t cast). Behavior-neutral cleanup,
deliberately split out of #10.

- decode_integer(): sign-extends 1-3 byte content with the top bit set
  (accumulator seeded with 0xffffffff); lengths >= 4 and all valid
  non-negative encodings decode exactly as before
- decode_unsigned(): new raw accumulator for content that is unsigned by
  definition - Counter32/Gauge32 in msgpack_pack_ber() and IpAddress
  bytes in decode_ipv4_address() - so BER-violating agent encodings
  (e.g. Counter32 128 sent as a bare 0x80 byte) keep decoding unchanged
- the msgpack_pack_ber() sign block collapses to a single int32_t cast
- test infra: SQE::FakeAgent gains minimal signed INTEGER encoding
  (_enc_int), replacing the accidental 9-byte two's-complement blob it
  emitted for negative values

Test plan:
- [x] t/test_ber.c: decode_integer sign cases (-1, -128, -129, -32768,
      -8388608, INT32_MIN, 4/5-byte and zero-length boundaries) and
      decode_unsigned no-extension/skip/short-buffer cases
- [x] t/behavior.t: negative INTEGER values (-5, -129, -32768, INT32_MIN)
      served by the fake agent end-to-end, plus _enc_int byte-level pins
- [x] full make test green; scan-build: No bugs found