### PR TITLE
fix: reject oversized BER length claims that overflow the bounds check

### DIFF
--- a/.changes/unreleased/Fixed-20260713-215604.yaml
+++ b/.changes/unreleased/Fixed-20260713-215604.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'ber: reject oversized length claims in decoded packets'
+time: 2026-07-13T21:56:04.953578+02:00

--- a/ber.c
+++ b/ber.c
@@ -10,10 +10,10 @@
 
 #include <openssl/evp.h>
 
-#define SPACECHECK(bytes)                \
-    if (e->len + (bytes) > e->max_len) { \
-        errno = EMSGSIZE;                \
-        return -1;                       \
+#define SPACECHECK(bytes)                                      \
+    if ((unsigned)(bytes) > (unsigned)(e->max_len - e->len)) { \
+        errno = EMSGSIZE;                                      \
+        return -1;                                             \
     }
 #define SPACECHECK2 SPACECHECK(2)
 #define EXTEND(bytes)      \

--- a/ber.c
+++ b/ber.c
@@ -886,7 +886,7 @@ decode_type_len(struct ber *e, unsigned char *type, unsigned *len)
         EXTEND(3);
     } else if (l == 0x84) {
         SPACECHECK(4);
-        l = (((e->b[0] << 8) | e->b[1]) << 8 | e->b[2]) << 8 | e->b[3];
+        l = (((unsigned)e->b[0] << 8 | e->b[1]) << 8 | e->b[2]) << 8 | e->b[3];
         EXTEND(4);
     } else {
         errno = ERANGE;

--- a/t/test_ber.c
+++ b/t/test_ber.c
@@ -253,6 +253,60 @@ test_decode_integer(const char *tlv, int tlv_len, unsigned expected)
 }
 
 int
+test_decode_type_len_hostile(void)
+{
+	/* 0x84 FF FF FF FF: a ~4GB long-form length claim. The final
+	 * SPACECHECK(l) must reject it; historically e->len + l wrapped in
+	 * unsigned arithmetic and the claim slipped through. */
+	unsigned char buf[6] = { 0x30, 0x84, 0xff, 0xff, 0xff, 0xff };
+	struct ber e = ber_init(buf, 6);
+	unsigned char t;
+	unsigned len;
+
+	if (decode_type_len(&e, &t, &len) == 0) {
+		tap_diag("decode_type_len: accepted hostile 0x84 ffffffff length (len=%#x)", len);
+		return 0;
+	}
+	return 1;
+}
+
+int
+test_decode_type_len_ok(void)
+{
+	/* 0x81-form length of 3 with 3 content bytes present: must be accepted. */
+	unsigned char buf[6] = { 0x04, 0x81, 0x03, 0x41, 0x42, 0x43 };
+	struct ber e = ber_init(buf, 6);
+	unsigned char t;
+	unsigned len;
+
+	if (decode_type_len(&e, &t, &len) < 0) {
+		tap_diag("decode_type_len: rejected a valid long-form length");
+		return 0;
+	}
+	if (t != 0x04 || len != 3) {
+		tap_diag("decode_type_len: got type=%#x len=%u, expected type=0x04 len=3", t, len);
+		return 0;
+	}
+	return 1;
+}
+
+int
+test_decode_type_len_short(void)
+{
+	/* 0x81-form length claims 5 content bytes but only 2 are present. */
+	unsigned char buf[5] = { 0x04, 0x81, 0x05, 0x41, 0x42 };
+	struct ber e = ber_init(buf, 5);
+	unsigned char t;
+	unsigned len;
+
+	if (decode_type_len(&e, &t, &len) == 0) {
+		tap_diag("decode_type_len: accepted length past buffer end (len=%#x)", len);
+		return 0;
+	}
+	return 1;
+}
+
+int
 test_next_sid_from(unsigned cur, unsigned expected)
 {
 	unsigned got;
@@ -555,6 +609,10 @@ main(void)
 	ok(test_decode_integer("\x02\x04\x80\x00\x00\x00", 6, 0x80000000u), "decode_integer INT32_MIN");
 	ok(test_decode_integer("\x02\x05\x00\xff\xff\xff\xff", 7, 0xffffffffu), "decode_integer 5-byte 0xffffffff");
 	ok(test_decode_integer("\x02\x00", 2, 0), "decode_integer zero-length content");
+
+	ok(test_decode_type_len_hostile(), "decode_type_len rejects hostile 0x84 ffffffff length");
+	ok(test_decode_type_len_ok(),      "decode_type_len accepts valid 0x81 long-form length");
+	ok(test_decode_type_len_short(),   "decode_type_len rejects length past buffer end");
 
 	ok(test_next_sid_from(0x01000000, 0x01000001), "next_sid_from 0x01000000");
 	ok(test_next_sid_from(0x01ffffff, 0x02000000), "next_sid_from 0x01ffffff");


### PR DESCRIPTION
`decode_type_len` checked a decoded BER length against the buffer with
`e->len + bytes > e->max_len`, which wraps in unsigned arithmetic: a hostile
`0x84 FF FF FF FF` claim (~4 GB) passed as if it fit. Rearranged `SPACECHECK`
to compare against available space so it can't overflow — behavior-neutral for
every legitimate length, rejects the oversized (and negative) cases.

Matters because `decode_type_len`'s "len bytes are available" contract backs
callers that then pack those bytes (e.g. `msgpack_pack_ber` AT_STRING has no
separate size guard); this hardens the parser against malformed agent
responses. No demonstrated exploit — the old wrap corrupted the slice rather
than over-reading.

Three new `t/test_ber.c` tests pin the contract: hostile claim rejected (red
before the fix), valid long-form accepted, over-buffer claim rejected.

## Test plan
- [x] `make test` — 505/505
- [x] scan-build clean
- [x] hostile-length test red before fix, green after