### PR TITLE
test: skip macOS leaks check when test binary is ASan-instrumented

### DIFF
--- a/t/cri.t
+++ b/t/cri.t
@@ -12,11 +12,17 @@ skip_all "$bin is not built (run make first)" unless -x $bin;
 my $plain = `$bin 2>&1`;
 is($? >> 8, 0, "test_cri scenario passes") or diag($plain);
 
+my $is_asan = `nm $bin 2>/dev/null` =~ /__asan/;
+
 if ($^O eq 'darwin' && grep { -x "$_/leaks" } split /:/, $ENV{PATH}) {
-	my $out = `leaks --atExit -- $bin 2>&1`;
-	like($out, qr/\b0 leaks for 0 total leaked bytes/, "no leaks (macOS leaks)")
-		or diag($out);
-} elsif (`nm $bin 2>/dev/null` =~ /__asan/) {
+	if ($is_asan) {
+		note "leaks cannot inspect ASan processes; leak check skipped";
+	} else {
+		my $out = `leaks --atExit -- $bin 2>&1`;
+		like($out, qr/\b0 leaks for 0 total leaked bytes/, "no leaks (macOS leaks)")
+			or diag($out);
+	}
+} elsif ($is_asan) {
 	local $ENV{ASAN_OPTIONS} = "detect_leaks=1";
 	my $out = `$bin 2>&1`;
 	my $rc = $? >> 8;


### PR DESCRIPTION
Under a local macOS sanitizer build (`OPTIMIZE="-O1 -g -fsanitize=address,undefined ..."`), `t/cri.t` always failed: it unconditionally ran `leaks --atExit` on darwin, but `leaks(1)` fatally refuses to inspect any ASan-instrumented process ("unable to inspect heap ranges"), and Apple's ASan does not support `detect_leaks` on macOS, so no in-process fallback exists.

Hoist the existing `nm`-based ASan detection into a variable and, on darwin with an ASan-built binary, skip the leaks invocation with a note. Darwin plain builds still run `leaks`; the LeakSanitizer branch for non-darwin ASan builds is unchanged, so leak coverage still comes from plain-build runs and the Linux CI sanitize job.

Test plan:
- [x] macOS ASan build: `prove t/cri.t` passes, leaks check skipped with note
- [x] macOS plain build: `prove t/cri.t` passes, `leaks --atExit` check runs
- [x] Full suite green under both sanitize (504) and plain (505) builds