### PR TITLE
fix: setopt rejects empty v3 credentials and wrong-size localized keys

### DIFF
--- a/.changes/unreleased/Fixed-20260715-113806.yaml
+++ b/.changes/unreleased/Fixed-20260715-113806.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'setopt: reject empty v3 credentials and wrong-size localized keys'
+time: 2026-07-15T11:38:06.043714+02:00

--- a/manual.mdwn
+++ b/manual.mdwn
@@ -207,7 +207,9 @@ Supported options:
 **`privprotocol`**
 :   Privacy protocol (for SNMPv3).  There is no default;  it is required in
     the same request as `privkul`.
-    Valid values are "des", "aes", "aes192", "aes256", "aes192c", and "aes256c".
+    Valid values are "des", "aes", "aes128", "aes192", "aes256", "aes192c",
+    and "aes256c".
+    "aes128" is synonymous to "aes".
     Only "aes" and "aes256c" are currently implemented.
     This is a per destination/client option which does
     not affect other clients.

--- a/manual.mdwn
+++ b/manual.mdwn
@@ -156,7 +156,7 @@ Supported options:
 
 **`engineid`**
 :   Authoritative SNMP engine ID of the destination (for SNMPv3).  The default is **""**.
-    Valid values must be (optionally space-separated) hex strings, for example
+    Valid values must be non-empty (optionally space-separated) hex strings, for example
     "39 6a 66 39 4d 5a 35 6b 68 49 72 61".
     If `engineid` is omitted, the engine discovers it from the agent on first
     use (RFC 3414 discovery) and then treats it as fixed until the options are
@@ -172,12 +172,16 @@ Supported options:
 
 **`username`**
 :   User name (for SNMPv3);  default is **""**.
+    A supplied value must be non-empty.
     This is a per destination/client option which does
     not affect other clients.
 
 **`authprotocol`**
-:   Authentication protocol (for SNMPv3);  default is **"sha1"**.
-    Valid values are "md5", "sha1", and "sha".
+:   Authentication protocol (for SNMPv3).  There is no default;  it must be
+    supplied for SNMPv3 operation, and is required in the same request as
+    `authkul` or `privkul`.
+    Valid values are "md5", "sha1", "sha", "sha224", "sha256", "sha384",
+    and "sha512".
     "sha" is synonymous to "sha1".
     "md5" is currently not implemented.
     This is a per destination/client option which does
@@ -185,6 +189,7 @@ Supported options:
 
 **`authpassword`**
 :   Authentication password (for SNMPv3);  default is **""**.
+    A supplied value must be non-empty.
     The `authpassword` is never returned by **GETOPT**
     (instead, `authkul` is computed and returned).
     This is a per destination/client option which does
@@ -192,13 +197,16 @@ Supported options:
 
 **`authkul`**
 :   Localized authentication key (for SNMPv3);  default is **""**.
-    Valid values must be (optionally space-separated) hex strings.
+    Valid values must be non-empty (optionally space-separated) hex strings,
+    exactly as long as the digest of the `authprotocol` supplied in the same
+    request: 20/28/32/48/64 bytes for sha1/sha224/sha256/sha384/sha512.
     It is an error to specify both `authpassword` and `authkul`.
     This is a per destination/client option which does
     not affect other clients.
 
 **`privprotocol`**
-:   Privacy protocol (for SNMPv3);  default is **"aes"**.
+:   Privacy protocol (for SNMPv3).  There is no default;  it is required in
+    the same request as `privkul`.
     Valid values are "des", "aes", "aes192", "aes256", "aes192c", and "aes256c".
     Only "aes" and "aes256c" are currently implemented.
     This is a per destination/client option which does
@@ -206,6 +214,7 @@ Supported options:
 
 **`privpassword`**
 :   Privacy password (for SNMPv3);  default is **""**.
+    A supplied value must be non-empty.
     The `privpassword` is never returned by **GETOPT**
     (instead, `privkul` is computed and returned).
     This is a per destination/client option which does
@@ -213,7 +222,9 @@ Supported options:
 
 **`privkul`**
 :   Localized privacy key (for SNMPv3);  default is **""**.
-    Valid values must be (optionally space-separated) hex strings.
+    Valid values must be non-empty (optionally space-separated) hex strings,
+    exactly as long as the digest of the `authprotocol` supplied in the same
+    request: 20/28/32/48/64 bytes for sha1/sha224/sha256/sha384/sha512.
     It is an error to specify both `privpassword` and `privkul`.
     This is a per destination/client option which does
     not affect other clients.

--- a/request_setopt.c
+++ b/request_setopt.c
@@ -307,6 +307,19 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 		v3.engine_state = V3_ENGINE_DISCOVERY;
 	}
 
+	if (seen_authkul || seen_privkul) {
+		int kul_len = v3_auth_kul_len(v3.auth_proto);
+
+		if (kul_len < 0)
+			return error_reply(si, RT_SETOPT|RT_ERROR, cid, "authprotocol is required with authkul/privkul");
+		if (seen_authkul && v3.authkul_len != (unsigned)kul_len)
+			return error_reply(si, RT_SETOPT|RT_ERROR, cid, "authkul length does not match auth protocol");
+		if (seen_privkul && v3.privkul_len != (unsigned)kul_len)
+			return error_reply(si, RT_SETOPT|RT_ERROR, cid, "privkul length does not match auth protocol");
+		if (seen_privkul && !v3.priv_proto)
+			return error_reply(si, RT_SETOPT|RT_ERROR, cid, "privprotocol is required with privkul");
+	}
+
 	if (need_v3 && v3.engine_state == V3_ENGINE_KNOWN && v3.authpass[0]) {
 		char *err;
 

--- a/request_setopt.c
+++ b/request_setopt.c
@@ -203,14 +203,14 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 			break;
 		case OPT_engineid:
 			hexlen = object_hexstring_to_buffer(v, v3.engine_id, V3O_ENGINE_ID_MAXLEN);
-			if (hexlen < 0)
+			if (hexlen <= 0)
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid engineid hexstring");
 			v3.engine_id_len = hexlen;
 			need_v3 = 1;
 			seen_engineid = 1;
 			break;
 		case OPT_username:
-			if (!object2string(v, v3.username, V3O_USERNAME_MAXSIZE))
+			if (!object2string(v, v3.username, V3O_USERNAME_MAXSIZE) || !v3.username[0])
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid username");
 			need_v3 = 1;
 			break;
@@ -236,7 +236,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 			need_v3 = 1;
 			break;
 		case OPT_authpassword:
-			if (!object2string(v, v3.authpass, V3O_AUTHPASS_MAXSIZE))
+			if (!object2string(v, v3.authpass, V3O_AUTHPASS_MAXSIZE) || !v3.authpass[0])
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid auth password");
 			seen_authpassword = 1;
 			v3.authkul_len = 0;
@@ -244,7 +244,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 			break;
 		case OPT_authkul:
 			hexlen = object_hexstring_to_buffer(v, v3.authkul, V3O_AUTHKUL_MAXSIZE);
-			if (hexlen < 0)
+			if (hexlen <= 0)
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid authkul hexstring");
 			v3.authkul_len = hexlen;
 			seen_authkul = 1;
@@ -276,7 +276,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 			need_v3 = 1;
 			break;
 		case OPT_privpassword:
-			if (!object2string(v, v3.privpass, V3O_PRIVPASS_MAXSIZE))
+			if (!object2string(v, v3.privpass, V3O_PRIVPASS_MAXSIZE) || !v3.privpass[0])
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid priv password");
 			seen_privpassword = 1;
 			v3.privkul_len = 0;
@@ -284,7 +284,7 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 			break;
 		case OPT_privkul:
 			hexlen = object_hexstring_to_buffer(v, v3.privkul, V3O_PRIVKUL_MAXSIZE);
-			if (hexlen < 0)
+			if (hexlen <= 0)
 				return error_reply(si, RT_SETOPT|RT_ERROR, cid, "invalid privkul hexstring");
 			v3.privkul_len = hexlen;
 			seen_privkul = 1;

--- a/snmp-query-engine.1
+++ b/snmp-query-engine.1
@@ -188,8 +188,9 @@ clients.
 Privacy protocol (for SNMPv3).
 There is no default; it is required in the same request as
 \f[CR]privkul\f[R].
-Valid values are \(lqdes\(rq, \(lqaes\(rq, \(lqaes192\(rq,
-\(lqaes256\(rq, \(lqaes192c\(rq, and \(lqaes256c\(rq.
+Valid values are \(lqdes\(rq, \(lqaes\(rq, \(lqaes128\(rq,
+\(lqaes192\(rq, \(lqaes256\(rq, \(lqaes192c\(rq, and \(lqaes256c\(rq.
+\(lqaes128\(rq is synonymous to \(lqaes\(rq.
 Only \(lqaes\(rq and \(lqaes256c\(rq are currently implemented.
 This is a per destination/client option which does not affect other
 clients.

--- a/snmp-query-engine.1
+++ b/snmp-query-engine.1
@@ -130,8 +130,8 @@ clients.
 \f[B]\f[CB]engineid\f[B]\f[R]
 Authoritative SNMP engine ID of the destination (for SNMPv3).
 The default is \f[B]\(lq\(lq\f[R].
-Valid values must be (optionally space\-separated) hex strings, for
-example \(lq39 6a 66 39 4d 5a 35 6b 68 49 72 61\(rq.
+Valid values must be non\-empty (optionally space\-separated) hex
+strings, for example \(lq39 6a 66 39 4d 5a 35 6b 68 49 72 61\(rq.
 If \f[CR]engineid\f[R] is omitted, the engine discovers it from the
 agent on first use (RFC 3414 discovery) and then treats it as fixed
 until the options are set again.
@@ -148,12 +148,17 @@ clients.
 .TP
 \f[B]\f[CB]username\f[B]\f[R]
 User name (for SNMPv3); default is \f[B]\(lq\(lq\f[R].
+A supplied value must be non\-empty.
 This is a per destination/client option which does not affect other
 clients.
 .TP
 \f[B]\f[CB]authprotocol\f[B]\f[R]
-Authentication protocol (for SNMPv3); default is \f[B]\(lqsha1\(rq\f[R].
-Valid values are \(lqmd5\(rq, \(lqsha1\(rq, and \(lqsha\(rq.
+Authentication protocol (for SNMPv3).
+There is no default; it must be supplied for SNMPv3 operation, and is
+required in the same request as \f[CR]authkul\f[R] or
+\f[CR]privkul\f[R].
+Valid values are \(lqmd5\(rq, \(lqsha1\(rq, \(lqsha\(rq, \(lqsha224\(rq,
+\(lqsha256\(rq, \(lqsha384\(rq, and \(lqsha512\(rq.
 \(lqsha\(rq is synonymous to \(lqsha1\(rq.
 \(lqmd5\(rq is currently not implemented.
 This is a per destination/client option which does not affect other
@@ -161,6 +166,7 @@ clients.
 .TP
 \f[B]\f[CB]authpassword\f[B]\f[R]
 Authentication password (for SNMPv3); default is \f[B]\(lq\(lq\f[R].
+A supplied value must be non\-empty.
 The \f[CR]authpassword\f[R] is never returned by \f[B]GETOPT\f[R]
 (instead, \f[CR]authkul\f[R] is computed and returned).
 This is a per destination/client option which does not affect other
@@ -169,14 +175,19 @@ clients.
 \f[B]\f[CB]authkul\f[B]\f[R]
 Localized authentication key (for SNMPv3); default is
 \f[B]\(lq\(lq\f[R].
-Valid values must be (optionally space\-separated) hex strings.
+Valid values must be non\-empty (optionally space\-separated) hex
+strings, exactly as long as the digest of the \f[CR]authprotocol\f[R]
+supplied in the same request: 20/28/32/48/64 bytes for
+sha1/sha224/sha256/sha384/sha512.
 It is an error to specify both \f[CR]authpassword\f[R] and
 \f[CR]authkul\f[R].
 This is a per destination/client option which does not affect other
 clients.
 .TP
 \f[B]\f[CB]privprotocol\f[B]\f[R]
-Privacy protocol (for SNMPv3); default is \f[B]\(lqaes\(rq\f[R].
+Privacy protocol (for SNMPv3).
+There is no default; it is required in the same request as
+\f[CR]privkul\f[R].
 Valid values are \(lqdes\(rq, \(lqaes\(rq, \(lqaes192\(rq,
 \(lqaes256\(rq, \(lqaes192c\(rq, and \(lqaes256c\(rq.
 Only \(lqaes\(rq and \(lqaes256c\(rq are currently implemented.
@@ -185,6 +196,7 @@ clients.
 .TP
 \f[B]\f[CB]privpassword\f[B]\f[R]
 Privacy password (for SNMPv3); default is \f[B]\(lq\(lq\f[R].
+A supplied value must be non\-empty.
 The \f[CR]privpassword\f[R] is never returned by \f[B]GETOPT\f[R]
 (instead, \f[CR]privkul\f[R] is computed and returned).
 This is a per destination/client option which does not affect other
@@ -192,7 +204,10 @@ clients.
 .TP
 \f[B]\f[CB]privkul\f[B]\f[R]
 Localized privacy key (for SNMPv3); default is \f[B]\(lq\(lq\f[R].
-Valid values must be (optionally space\-separated) hex strings.
+Valid values must be non\-empty (optionally space\-separated) hex
+strings, exactly as long as the digest of the \f[CR]authprotocol\f[R]
+supplied in the same request: 20/28/32/48/64 bytes for
+sha1/sha224/sha256/sha384/sha512.
 It is an error to specify both \f[CR]privpassword\f[R] and
 \f[CR]privkul\f[R].
 This is a per destination/client option which does not affect other

--- a/sqe.h
+++ b/sqe.h
@@ -686,6 +686,8 @@ struct evp_md_st;  /* == OpenSSL EVP_MD; forward-declared to keep openssl out of
 extern const struct evp_md_st *v3_auth_md(int auth_proto);
 /* MAC truncation length in bytes (12/16/24/32/48), or a negative sentinel for unsupported protocols */
 extern int v3_auth_maclen(int auth_proto);
+/* localized-key (kul) length in bytes (20/28/32/48/64), or a negative sentinel for unsupported protocols */
+extern int v3_auth_kul_len(int auth_proto);
 
 extern int encrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const struct snmpv3info *v3);
 extern int decrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const struct snmpv3info *v3);

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -147,6 +147,17 @@ request_match($d, "setopt empty privkul", [RT_SETOPT,2240,"127.0.0.1",161,{privk
 request_match($d, "setopt empty username", [RT_SETOPT,2241,"127.0.0.1",161,{username=>""}], [RT_SETOPT|RT_ERROR,2241,qr/invalid username/]);
 request_match($d, "setopt empty authpassword", [RT_SETOPT,2242,"127.0.0.1",161,{authpassword=>""}], [RT_SETOPT|RT_ERROR,2242,qr/invalid auth password/]);
 request_match($d, "setopt empty privpassword", [RT_SETOPT,2243,"127.0.0.1",161,{privpassword=>""}], [RT_SETOPT|RT_ERROR,2243,qr/invalid priv password/]);
+
+my $kul32 = "ab" x 32;
+my $kul20 = "cd" x 20;
+my $v3eid = "0a0b0c0d0e";
+request_match($d, "setopt authkul without authprotocol", [RT_SETOPT,2244,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authkul=>$kul32}], [RT_SETOPT|RT_ERROR,2244,qr{authprotocol is required with authkul/privkul}]);
+request_match($d, "setopt privkul without authprotocol", [RT_SETOPT,2245,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", privprotocol=>"aes", privkul=>$kul32}], [RT_SETOPT|RT_ERROR,2245,qr{authprotocol is required with authkul/privkul}]);
+request_match($d, "setopt authkul wrong length", [RT_SETOPT,2246,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul20}], [RT_SETOPT|RT_ERROR,2246,qr/authkul length does not match auth protocol/]);
+request_match($d, "setopt privkul wrong length", [RT_SETOPT,2247,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul32, privprotocol=>"aes", privkul=>$kul20}], [RT_SETOPT|RT_ERROR,2247,qr/privkul length does not match auth protocol/]);
+request_match($d, "setopt privkul without privprotocol", [RT_SETOPT,2248,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul32, privkul=>$kul32}], [RT_SETOPT|RT_ERROR,2248,qr/privprotocol is required with privkul/]);
+request_match($d, "setopt correct kuls accepted", [RT_SETOPT,2249,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul32, privprotocol=>"aes", privkul=>$kul32}], [RT_SETOPT|RT_REPLY,2249,{engineid=>$v3eid, authkul=>$kul32, privkul=>$kul32}]);
+
 request_match($d, "defaults unchanged", [RT_SETOPT,2023,"127.0.0.1",161, {}], [RT_SETOPT|RT_REPLY,2023,
 	{ip=>"127.0.0.1", port=>161, community=>"public", version=>2, max_packets => 3, max_req_size => 1400, timeout => 2000, retries => 3, min_interval => 10, max_repetitions => 10, }]);
 request_match($d, "change timeout", [RT_SETOPT,2024,"127.0.0.1",161, {timeout=>1500}], [RT_SETOPT|RT_REPLY,2024,

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -140,6 +140,13 @@ request_match($d, "setopt bad authkul 1", [RT_SETOPT,2233,"127.0.0.1",161,{authk
 request_match($d, "setopt bad authkul 2", [RT_SETOPT,2234,"127.0.0.1",161,{authkul=>"abc"}], [RT_SETOPT|RT_ERROR,2234,qr/invalid authkul hexstring/]);
 request_match($d, "setopt bad privkul 1", [RT_SETOPT,2235,"127.0.0.1",161,{privkul=>"zz"}], [RT_SETOPT|RT_ERROR,2235,qr/invalid privkul hexstring/]);
 request_match($d, "setopt bad privkul 2", [RT_SETOPT,2236,"127.0.0.1",161,{privkul=>"ab" x 65}], [RT_SETOPT|RT_ERROR,2236,qr/invalid privkul hexstring/]);
+request_match($d, "setopt empty engineid", [RT_SETOPT,2237,"127.0.0.1",161,{engineid=>""}], [RT_SETOPT|RT_ERROR,2237,qr/invalid engineid hexstring/]);
+request_match($d, "setopt blank engineid", [RT_SETOPT,2238,"127.0.0.1",161,{engineid=>" "}], [RT_SETOPT|RT_ERROR,2238,qr/invalid engineid hexstring/]);
+request_match($d, "setopt empty authkul", [RT_SETOPT,2239,"127.0.0.1",161,{authkul=>""}], [RT_SETOPT|RT_ERROR,2239,qr/invalid authkul hexstring/]);
+request_match($d, "setopt empty privkul", [RT_SETOPT,2240,"127.0.0.1",161,{privkul=>""}], [RT_SETOPT|RT_ERROR,2240,qr/invalid privkul hexstring/]);
+request_match($d, "setopt empty username", [RT_SETOPT,2241,"127.0.0.1",161,{username=>""}], [RT_SETOPT|RT_ERROR,2241,qr/invalid username/]);
+request_match($d, "setopt empty authpassword", [RT_SETOPT,2242,"127.0.0.1",161,{authpassword=>""}], [RT_SETOPT|RT_ERROR,2242,qr/invalid auth password/]);
+request_match($d, "setopt empty privpassword", [RT_SETOPT,2243,"127.0.0.1",161,{privpassword=>""}], [RT_SETOPT|RT_ERROR,2243,qr/invalid priv password/]);
 request_match($d, "defaults unchanged", [RT_SETOPT,2023,"127.0.0.1",161, {}], [RT_SETOPT|RT_REPLY,2023,
 	{ip=>"127.0.0.1", port=>161, community=>"public", version=>2, max_packets => 3, max_req_size => 1400, timeout => 2000, retries => 3, min_interval => 10, max_repetitions => 10, }]);
 request_match($d, "change timeout", [RT_SETOPT,2024,"127.0.0.1",161, {timeout=>1500}], [RT_SETOPT|RT_REPLY,2024,

--- a/t/test_v3.c
+++ b/t/test_v3.c
@@ -165,5 +165,14 @@ main(void)
     check_hmac("sha384", V3O_AUTH_PROTO_SHA384);
     check_hmac("sha512", V3O_AUTH_PROTO_SHA512);
 
+    /* localized-key length per protocol */
+    is_int(v3_auth_kul_len(V3O_AUTH_PROTO_SHA1), 20, "sha1 kul length");
+    is_int(v3_auth_kul_len(V3O_AUTH_PROTO_SHA224), 28, "sha224 kul length");
+    is_int(v3_auth_kul_len(V3O_AUTH_PROTO_SHA256), 32, "sha256 kul length");
+    is_int(v3_auth_kul_len(V3O_AUTH_PROTO_SHA384), 48, "sha384 kul length");
+    is_int(v3_auth_kul_len(V3O_AUTH_PROTO_SHA512), 64, "sha512 kul length");
+    is_int(v3_auth_kul_len(V3O_AUTH_PROTO_MD5), -1, "md5 kul length unsupported");
+    is_int(v3_auth_kul_len(0), -1, "absent auth proto kul length unsupported");
+
     return tap_done();
 }

--- a/v3_crypto.c
+++ b/v3_crypto.c
@@ -44,6 +44,21 @@ v3_auth_maclen(int auth_proto)
     }
 }
 
+/// @brief Localized authentication key (kul) length for a protocol
+/// @return the length in bytes, or -1 if the protocol is unsupported
+int
+v3_auth_kul_len(int auth_proto)
+{
+    switch (auth_proto) {
+    case V3O_AUTH_PROTO_SHA1:   return 20;
+    case V3O_AUTH_PROTO_SHA224: return 28;
+    case V3O_AUTH_PROTO_SHA256: return 32;
+    case V3O_AUTH_PROTO_SHA384: return 48;
+    case V3O_AUTH_PROTO_SHA512: return 64;
+    default:                    return -1;
+    }
+}
+
 int
 hmac_message(const struct snmpv3info* v3,
              unsigned char* out,


### PR DESCRIPTION
Setopt accepted empty values for all six SNMPv3 credential options
(engineid, username, authpassword, authkul, privpassword, privkul) and
localized keys of any length. Each such setopt "succeeded" and every
subsequent query timed out with no hint why — an empty engineid even
suppressed engine-id discovery, because it marked the engine id as known.

This change makes setopt fail fast instead:

- empty values for the six v3 credential options are rejected with the
  existing per-key error messages;
- authkul/privkul must match the digest length of the authprotocol
  supplied in the same request (new v3_auth_kul_len helper);
- authkul/privkul without authprotocol, and privkul without privprotocol,
  are now proper setopt errors (the latter previously surfaced as a
  cryptic "x_privkul calculation error").

The manual's v3 option descriptions are updated accordingly, which also
corrects two stale claims: authprotocol/privprotocol have no defaults
(the documented "sha1"/"aes" defaults never existed in code), and the
authprotocol value list now includes the sha224-sha512 protocols.

Test plan:

- [x] new t/protocol.t cases: empty value for each of the six keys;
      kul/protocol cross-field errors; correct-kul positive control
- [x] new t/test_v3.c assertions for v3_auth_kul_len
- [x] full suite green (make test)
- [x] scan-build: No bugs found
- [x] full suite green under ASan+UBSan