### PR TITLE
fix: setopt accepts cipher-length privkul localized keys

### DIFF
--- a/.changes/unreleased/Fixed-20260716-134605.yaml
+++ b/.changes/unreleased/Fixed-20260716-134605.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'setopt: accept cipher-length privkul localized keys'
+time: 2026-07-16T13:46:05.402967+02:00

--- a/manual.mdwn
+++ b/manual.mdwn
@@ -225,8 +225,10 @@ Supported options:
 **`privkul`**
 :   Localized privacy key (for SNMPv3);  default is **""**.
     Valid values must be non-empty (optionally space-separated) hex strings,
-    exactly as long as the digest of the `authprotocol` supplied in the same
-    request: 20/28/32/48/64 bytes for sha1/sha224/sha256/sha384/sha512.
+    either as long as the digest of the `authprotocol` supplied in the same
+    request (20/28/32/48/64 bytes for sha1/sha224/sha256/sha384/sha512), or
+    as long as the cipher key of the `privprotocol` supplied in the same
+    request (16 bytes for aes, 32 bytes for aes256c).
     It is an error to specify both `privpassword` and `privkul`.
     This is a per destination/client option which does
     not affect other clients.

--- a/request_setopt.c
+++ b/request_setopt.c
@@ -314,10 +314,11 @@ handle_setopt_request(struct socket_info *si, unsigned cid, msgpack_object *o)
 			return error_reply(si, RT_SETOPT|RT_ERROR, cid, "authprotocol is required with authkul/privkul");
 		if (seen_authkul && v3.authkul_len != (unsigned)kul_len)
 			return error_reply(si, RT_SETOPT|RT_ERROR, cid, "authkul length does not match auth protocol");
-		if (seen_privkul && v3.privkul_len != (unsigned)kul_len)
-			return error_reply(si, RT_SETOPT|RT_ERROR, cid, "privkul length does not match auth protocol");
 		if (seen_privkul && !v3.priv_proto)
 			return error_reply(si, RT_SETOPT|RT_ERROR, cid, "privprotocol is required with privkul");
+		if (seen_privkul && v3.privkul_len != (unsigned)kul_len
+		    && (int)v3.privkul_len != v3_priv_key_len(v3.priv_proto))
+			return error_reply(si, RT_SETOPT|RT_ERROR, cid, "privkul length matches neither auth nor priv protocol");
 	}
 
 	if (need_v3 && v3.engine_state == V3_ENGINE_KNOWN && v3.authpass[0]) {

--- a/snmp-query-engine.1
+++ b/snmp-query-engine.1
@@ -206,9 +206,11 @@ clients.
 \f[B]\f[CB]privkul\f[B]\f[R]
 Localized privacy key (for SNMPv3); default is \f[B]\(lq\(lq\f[R].
 Valid values must be non\-empty (optionally space\-separated) hex
-strings, exactly as long as the digest of the \f[CR]authprotocol\f[R]
-supplied in the same request: 20/28/32/48/64 bytes for
-sha1/sha224/sha256/sha384/sha512.
+strings, either as long as the digest of the \f[CR]authprotocol\f[R]
+supplied in the same request (20/28/32/48/64 bytes for
+sha1/sha224/sha256/sha384/sha512), or as long as the cipher key of the
+\f[CR]privprotocol\f[R] supplied in the same request (16 bytes for aes,
+32 bytes for aes256c).
 It is an error to specify both \f[CR]privpassword\f[R] and
 \f[CR]privkul\f[R].
 This is a per destination/client option which does not affect other

--- a/sqe.h
+++ b/sqe.h
@@ -688,6 +688,7 @@ extern const struct evp_md_st *v3_auth_md(int auth_proto);
 extern int v3_auth_maclen(int auth_proto);
 /* localized-key (kul) length in bytes (20/28/32/48/64), or a negative sentinel for unsupported protocols */
 extern int v3_auth_kul_len(int auth_proto);
+extern int v3_priv_key_len(int priv_proto);
 
 extern int encrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const struct snmpv3info *v3);
 extern int decrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const struct snmpv3info *v3);

--- a/sqe.h
+++ b/sqe.h
@@ -688,6 +688,7 @@ extern const struct evp_md_st *v3_auth_md(int auth_proto);
 extern int v3_auth_maclen(int auth_proto);
 /* localized-key (kul) length in bytes (20/28/32/48/64), or a negative sentinel for unsupported protocols */
 extern int v3_auth_kul_len(int auth_proto);
+/* cipher key size in bytes (16/32), or a negative sentinel for unsupported protocols */
 extern int v3_priv_key_len(int priv_proto);
 
 extern int encrypt_in_place(unsigned char *buf, int buf_len, unsigned char *privp, const struct snmpv3info *v3);

--- a/t/behavior-v3.t
+++ b/t/behavior-v3.t
@@ -420,5 +420,24 @@ for my $i (0 .. $#faults) {
 	$asilent->stop;
 }
 
+# cipher-truncated privkul, as sent by Net::SNMP-style clients, polls end-to-end
+{
+	my %v3s = (%v3, auth_proto => 'sha512');
+	my $a16 = SQE::FakeAgent->spawn(tree => \@tree, v3 => \%v3s);
+	my $eid = pack 'H*', $v3s{engine_id};
+	my $authkul = unpack 'H*', SQE::USM::password_to_kul('sha512', $v3s{auth_pass}, $eid);
+	my $privkul = unpack 'H*', SQE::USM::priv_key('sha512', $v3s{priv_pass}, $eid);
+	request_match($d, 'setopt accepts a 16-byte privkul with sha512 auth',
+		[RT_SETOPT, 700, $target, $a16->port, {
+			version => 3, engineid => $v3s{engine_id}, username => $v3s{username},
+			authprotocol => 'sha512', authkul => $authkul,
+			privprotocol => 'aes128', privkul => $privkul }],
+		[RT_SETOPT|RT_REPLY, 700, T()]);
+	request_match($d, 'v3 authPriv get succeeds with a cipher-truncated privkul',
+		[RT_GET, 701, $target, $a16->port, ['1.3.6.1.2.1.1.5.0']],
+		[RT_GET|RT_REPLY, 701, [['1.3.6.1.2.1.1.5.0', $hostname]]]);
+	$a16->stop;
+}
+
 $d->stop;
 done_testing;

--- a/t/protocol.t
+++ b/t/protocol.t
@@ -148,15 +148,27 @@ request_match($d, "setopt empty username", [RT_SETOPT,2241,"127.0.0.1",161,{user
 request_match($d, "setopt empty authpassword", [RT_SETOPT,2242,"127.0.0.1",161,{authpassword=>""}], [RT_SETOPT|RT_ERROR,2242,qr/invalid auth password/]);
 request_match($d, "setopt empty privpassword", [RT_SETOPT,2243,"127.0.0.1",161,{privpassword=>""}], [RT_SETOPT|RT_ERROR,2243,qr/invalid priv password/]);
 
-my $kul32 = "ab" x 32;
+my $kul16 = "ef" x 16;
 my $kul20 = "cd" x 20;
+my $kul28 = "ab" x 28;
+my $kul32 = "ab" x 32;
+my $kul48 = "ab" x 48;
+my $kul64 = "ab" x 64;
 my $v3eid = "0a0b0c0d0e";
 request_match($d, "setopt authkul without authprotocol", [RT_SETOPT,2244,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authkul=>$kul32}], [RT_SETOPT|RT_ERROR,2244,qr{authprotocol is required with authkul/privkul}]);
 request_match($d, "setopt privkul without authprotocol", [RT_SETOPT,2245,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", privprotocol=>"aes", privkul=>$kul32}], [RT_SETOPT|RT_ERROR,2245,qr{authprotocol is required with authkul/privkul}]);
 request_match($d, "setopt authkul wrong length", [RT_SETOPT,2246,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul20}], [RT_SETOPT|RT_ERROR,2246,qr/authkul length does not match auth protocol/]);
-request_match($d, "setopt privkul wrong length", [RT_SETOPT,2247,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul32, privprotocol=>"aes", privkul=>$kul20}], [RT_SETOPT|RT_ERROR,2247,qr/privkul length does not match auth protocol/]);
+request_match($d, "setopt privkul length matching neither protocol", [RT_SETOPT,2247,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul32, privprotocol=>"aes", privkul=>$kul20}], [RT_SETOPT|RT_ERROR,2247,qr/privkul length matches neither auth nor priv protocol/]);
 request_match($d, "setopt privkul without privprotocol", [RT_SETOPT,2248,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul32, privkul=>$kul32}], [RT_SETOPT|RT_ERROR,2248,qr/privprotocol is required with privkul/]);
-request_match($d, "setopt correct kuls accepted", [RT_SETOPT,2249,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul32, privprotocol=>"aes", privkul=>$kul32}], [RT_SETOPT|RT_REPLY,2249,{engineid=>$v3eid, authkul=>$kul32, privkul=>$kul32}]);
+request_match($d, "setopt digest-length kuls accepted", [RT_SETOPT,2249,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul32, privprotocol=>"aes", privkul=>$kul32}], [RT_SETOPT|RT_REPLY,2249,{engineid=>$v3eid, authkul=>$kul32, privkul=>$kul32}]);
+request_match($d, "setopt cipher-length privkul accepted (sha1)", [RT_SETOPT,2250,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha1", authkul=>$kul20, privprotocol=>"aes", privkul=>$kul16}], [RT_SETOPT|RT_REPLY,2250,{engineid=>$v3eid, authkul=>$kul20, privkul=>$kul16}]);
+request_match($d, "setopt cipher-length privkul accepted (sha224)", [RT_SETOPT,2251,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha224", authkul=>$kul28, privprotocol=>"aes", privkul=>$kul16}], [RT_SETOPT|RT_REPLY,2251,{engineid=>$v3eid, authkul=>$kul28, privkul=>$kul16}]);
+request_match($d, "setopt cipher-length privkul accepted (sha256)", [RT_SETOPT,2252,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha256", authkul=>$kul32, privprotocol=>"aes", privkul=>$kul16}], [RT_SETOPT|RT_REPLY,2252,{engineid=>$v3eid, authkul=>$kul32, privkul=>$kul16}]);
+request_match($d, "setopt cipher-length privkul accepted (sha384)", [RT_SETOPT,2253,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha384", authkul=>$kul48, privprotocol=>"aes", privkul=>$kul16}], [RT_SETOPT|RT_REPLY,2253,{engineid=>$v3eid, authkul=>$kul48, privkul=>$kul16}]);
+request_match($d, "setopt cipher-length privkul accepted (sha512, the v2.2.0 regression)", [RT_SETOPT,2254,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha512", authkul=>$kul64, privprotocol=>"aes", privkul=>$kul16}], [RT_SETOPT|RT_REPLY,2254,{engineid=>$v3eid, authkul=>$kul64, privkul=>$kul16}]);
+request_match($d, "setopt cipher-length privkul accepted (aes256c)", [RT_SETOPT,2255,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha512", authkul=>$kul64, privprotocol=>"aes256c", privkul=>$kul32}], [RT_SETOPT|RT_REPLY,2255,{engineid=>$v3eid, authkul=>$kul64, privkul=>$kul32}]);
+request_match($d, "setopt digest-length privkul accepted (sha1 + aes256c)", [RT_SETOPT,2256,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha1", authkul=>$kul20, privprotocol=>"aes256c", privkul=>$kul20}], [RT_SETOPT|RT_REPLY,2256,{engineid=>$v3eid, authkul=>$kul20, privkul=>$kul20}]);
+request_match($d, "setopt privkul matching neither (sha512 + aes256c)", [RT_SETOPT,2257,"127.0.0.1",1610,{engineid=>$v3eid, username=>"u", authprotocol=>"sha512", authkul=>$kul64, privprotocol=>"aes256c", privkul=>$kul16}], [RT_SETOPT|RT_ERROR,2257,qr/privkul length matches neither auth nor priv protocol/]);
 
 request_match($d, "defaults unchanged", [RT_SETOPT,2023,"127.0.0.1",161, {}], [RT_SETOPT|RT_REPLY,2023,
 	{ip=>"127.0.0.1", port=>161, community=>"public", version=>2, max_packets => 3, max_req_size => 1400, timeout => 2000, retries => 3, min_interval => 10, max_repetitions => 10, }]);

--- a/t/test_v3.c
+++ b/t/test_v3.c
@@ -174,5 +174,11 @@ main(void)
     is_int(v3_auth_kul_len(V3O_AUTH_PROTO_MD5), -1, "md5 kul length unsupported");
     is_int(v3_auth_kul_len(0), -1, "absent auth proto kul length unsupported");
 
+    is_int(v3_priv_key_len(V3O_PRIV_PROTO_AES), 16, "aes priv key length");
+    is_int(v3_priv_key_len(V3O_PRIV_PROTO_AES128), 16, "aes128 priv key length");
+    is_int(v3_priv_key_len(V3O_PRIV_PROTO_AES256_CISCO), 32, "aes256c priv key length");
+    is_int(v3_priv_key_len(V3O_PRIV_PROTO_DES), -1, "des priv key length unsupported");
+    is_int(v3_priv_key_len(0), -1, "absent priv proto key length unsupported");
+
     return tap_done();
 }

--- a/v3_crypto.c
+++ b/v3_crypto.c
@@ -59,6 +59,18 @@ v3_auth_kul_len(int auth_proto)
     }
 }
 
+/// Cipher key size in bytes of the localized privacy key for a priv protocol.
+/// @return the length in bytes, or -1 if the protocol is unsupported
+int
+v3_priv_key_len(int priv_proto)
+{
+    switch (priv_proto) {
+    case V3O_PRIV_PROTO_AES128:       return 16;
+    case V3O_PRIV_PROTO_AES256_CISCO: return 32;
+    default:                          return -1;
+    }
+}
+
 int
 hmac_message(const struct snmpv3info* v3,
              unsigned char* out,

--- a/v3_crypto.c
+++ b/v3_crypto.c
@@ -59,7 +59,7 @@ v3_auth_kul_len(int auth_proto)
     }
 }
 
-/// Cipher key size in bytes of the localized privacy key for a priv protocol.
+/// @brief Cipher key size in bytes of the localized privacy key for a priv protocol.
 /// @return the length in bytes, or -1 if the protocol is unsupported
 int
 v3_priv_key_len(int priv_proto)


### PR DESCRIPTION
v2.2.0 (PR #42) required privkul to be exactly as long as the auth
protocol's digest. Real clients — anything deriving keys via Net::SNMP's
USM, and per RFC 3826 itself, which defines the AES-128 privacy key as
128 bits — send the cipher-truncated localized priv key: 16 bytes for
AES-128 regardless of auth protocol. With authprotocol=sha512 the check
demanded 64 bytes, so every such SETOPT was rejected with "privkul length
does not match auth protocol", breaking production deployments that
worked on v2.1.0.

This change accepts a privkul at either of the two lengths that occur in
practice:

- the auth digest length (the localization intermediate; unchanged), or
- the priv protocol's cipher key size: 16 bytes for aes, 32 for aes256c
  (new v3_priv_key_len helper).

Anything else is still rejected fail-fast, now with "privkul length
matches neither auth nor priv protocol". The authkul digest-length rule
is untouched (standards-correct), and "privprotocol is required with
privkul" now fires before the length check, since the rule depends on it.

Test plan:

- [x] t/protocol.t: re-derived kul matrix — cipher-length privkul accepted
      with every auth protocol (sha512+16 bytes is the field regression),
      digest-length still accepted, aes256c at 32 bytes and digest length,
      neither-length cases still rejected
- [x] t/behavior-v3.t: end-to-end FakeAgent round-trip — a 16-byte privkul
      with sha512 auth actually polls
- [x] t/test_v3.c: v3_priv_key_len assertions
- [x] manual.mdwn privkul description updated, man page regenerated
- [x] full suite green (make test)
- [x] scan-build: No bugs found
- [x] full suite green under ASan+UBSan