### PR TITLE
Fully static Linux release binaries

### DIFF
--- a/.changes/unreleased/Fixed-20260815-211831.yaml
+++ b/.changes/unreleased/Fixed-20260815-211831.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: 'release binaries: fully static, run regardless of the system''s glibc version'
+time: 2026-08-15T21:18:31.698307+02:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,32 @@ jobs:
           name: linux-${{ matrix.arch }}
           path: snmp-query-engine-*-linux-*
 
+  smoke-old-glibc:
+    needs: linux-binary
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-22.04
+            arch: x86_64
+          - runner: ubuntu-22.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.runner }}
+    container: ubuntu:20.04
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: linux-${{ matrix.arch }}
+      - name: Run the binary on glibc 2.31
+        run: |
+          BIN=$(echo snmp-query-engine-*-linux-${{ matrix.arch }})
+          chmod +x "$BIN"
+          "./$BIN" -v
+          "./$BIN" -v | grep -q '^snmp-query-engine '
+
   release:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: [tarball, linux-binary]
+    needs: [tarball, linux-binary, smoke-old-glibc]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   STATIC_LIBS: >-
-    -Wl,-Bstatic -lJudy -lmsgpackc -lcrypto -Wl,-Bdynamic -ldl -pthread
+    -static -lJudy -lmsgpackc -lcrypto -pthread
 
 jobs:
   tarball:
@@ -51,8 +51,8 @@ jobs:
         run: make LIBS="$STATIC_LIBS"
       - name: Verify static linking
         run: |
-          ldd snmp-query-engine
-          ! ldd snmp-query-engine | grep -E 'msgpack|Judy|crypto'
+          file snmp-query-engine
+          file snmp-query-engine | grep -q 'statically linked'
           ./snmp-query-engine -v
       - name: Test
         run: make LIBS="$STATIC_LIBS" test


### PR DESCRIPTION
Release binaries were linked against the build runner's glibc (ubuntu-22.04,
glibc 2.35) and fail to start on hosts with older glibc. Link them fully
static instead — Judy, msgpack-c, and libcrypto were already static; this
extends that to glibc and drops the now-unneeded -ldl.

Adds a per-arch smoke job that executes the built binary inside an
ubuntu:20.04 container (glibc 2.31) and gates the release job on it, so the
no-glibc-floor property is enforced by CI on every release.

Known property, unchanged from v2.2.1: with libcrypto static, OpenSSL's
dynamically loaded legacy provider (DES privacy) is unavailable; SHA/AES
paths use the built-in default provider.

## Test plan

- [x] Dispatch run with the smoke job against the old link flags: smoke FAILS with `version 'GLIBC_2.34' not found`
- [x] Dispatch run after the -static switch: all jobs green (full test suite runs against the static binary; smoke passes on glibc 2.31)